### PR TITLE
Fix #28: key stream dedup on (name, m3u_account)

### DIFF
--- a/Stream-Mapparr/plugin.py
+++ b/Stream-Mapparr/plugin.py
@@ -1987,26 +1987,35 @@ class Plugin:
                 return True
 
     def _deduplicate_streams(self, streams):
-        """Remove duplicate streams based on stream name.
-        
-        Keeps the first occurrence of each unique stream name.
-        This prevents duplicate stream counts in results.
-        
+        """Remove duplicate streams based on (stream name, M3U account).
+
+        Keeps the first occurrence of each unique (name, M3U account) pair.
+        Identically-named streams from DIFFERENT sources are preserved so each
+        channel can hold one stream per provider (multi-source failover, see
+        issue #28). This covers both Standard M3U and Xtream Codes accounts,
+        since Dispatcharr stores both as M3UAccount rows referenced by
+        Stream.m3u_account. Only true duplicates within the same provider
+        collapse.
+
         Args:
             streams: List of stream dictionaries
-            
+
         Returns:
             List of deduplicated stream dictionaries
         """
-        seen_names = set()
+        seen_keys = set()
         deduplicated = []
-        
+
         for stream in streams:
             stream_name = stream.get('name', '')
-            if stream_name and stream_name not in seen_names:
-                seen_names.add(stream_name)
+            # Key on (name, M3U account) so the same name from two different
+            # sources both survive. Streams without an account share the key
+            # (name, None), which is fine for non-M3U streams.
+            dedup_key = (stream_name, stream.get('m3u_account'))
+            if stream_name and dedup_key not in seen_keys:
+                seen_keys.add(dedup_key)
                 deduplicated.append(stream)
-        
+
         return deduplicated
 
     def _load_channels_data(self, logger, settings=None):


### PR DESCRIPTION
## Problem
Fixes #28. When two or more sources (M3U or Xtream Codes) carry channels with
identical names, only one stream is assigned to each channel — the other
provider's stream is dropped, so multi-source failover doesn't work.

## Cause
`_deduplicate_streams` keys solely on stream **name**, so an identically-named
stream from a second account is discarded before assignment.

## Fix
Key de-duplication on **`(name, m3u_account)`**. Identical names from *different*
accounts are preserved; only true duplicates *within the same provider* collapse.
Covers both Standard M3U and Xtream Codes accounts, since Dispatcharr stores both
as `M3UAccount` rows referenced by `Stream.m3u_account`. `m3u_account` is already
loaded on every stream dict by `_get_all_streams`, so no extra queries are added.

## Testing
With two sources both carrying `4K| ESPN UHD`, the channel now receives 2 streams
(one per provider) instead of 1. Single-source lineups and same-provider
duplicates are unaffected.