### PR TITLE
Add automated test suite, CI, and dev workflow (+ bug-026 matcher fix)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# The git hook is executed by bash; CRLF would break it (\r: command not found).
+.githooks/pre-commit text eol=lf
+*.sh text eol=lf

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Stream-Mapparr pre-commit gate. Fast checks only (target: < 2s).
+#
+# Enable once per clone:
+#     git config core.hooksPath .githooks
+#
+# Bypass in an emergency with:  git commit --no-verify
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+PY="${PYTHON:-python}"
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+echo "[pre-commit] byte-compiling plugin sources..."
+"$PY" -m py_compile Stream-Mapparr/plugin.py Stream-Mapparr/fuzzy_matcher.py Stream-Mapparr/__init__.py
+
+echo "[pre-commit] checking version sync..."
+"$PY" scripts/check_version_sync.py
+
+echo "[pre-commit] validating channel databases..."
+"$PY" scripts/validate_databases.py >/dev/null
+
+echo "[pre-commit] running fast unit tests..."
+# Skip the multi-MB database schema tests here (CI covers them); keep the hook snappy.
+"$PY" -m pytest -q tests/test_fuzzy_matcher.py tests/test_plugin_helpers.py tests/test_version_sync.py
+
+echo "[pre-commit] OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+
+      # Compilation does not execute imports, so this passes without Django/the
+      # Dispatcharr ORM installed — it catches syntax errors before deploy.
+      - name: Byte-compile plugin sources
+        run: |
+          python -m py_compile Stream-Mapparr/plugin.py
+          python -m py_compile Stream-Mapparr/fuzzy_matcher.py
+          python -m py_compile Stream-Mapparr/__init__.py
+
+      - name: Version sync (plugin.json == plugin.py)
+        run: python scripts/check_version_sync.py
+
+      - name: Validate channel databases
+        run: python scripts/validate_databases.py
+
+      - name: Run test suite
+        run: python -m pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,28 @@ copilot-instructions.md
 # Local session files
 *.zip
 *.txt
+!requirements-dev.txt
 C--Users-btoll-claude-dispatcharr-Stream-Mapparr/
 docs/superpowers/
+# Local archive of historical per-version notes (decluttered out of the repo root)
+docs/history/
+
+# OpenWolf session/memory state (local context tooling, not source)
+.wolf/
+
+# Per-version dev-doc explosion. The consolidated Stream-Mapparr/CHANGELOG.md is
+# the source of truth; archive historical notes under docs/history/ rather than
+# committing one file per version/bug at the repo root.
+BUG_*.md
+BUGFIX_*.md
+CHANGELOG_v*.md
+CHANGES_SUMMARY*.md
+IMPLEMENTATION_SUMMARY*.md
+QUICK_*.md
+RELEASE_SUMMARY*.md
+*_SUMMARY.md
+*_PLAN.md
+*_GUIDE*.md
+*_COMPLETE.md
+# CSV exports produced by dry-run / sort actions
+*.csv

--- a/Stream-Mapparr/CHANGELOG.md
+++ b/Stream-Mapparr/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Stream-Mapparr CHANGELOG
 
+## Unreleased
+
+**Type**: Bugfix + developer-tooling (no plugin version bump yet; bundle into the next release).
+
+### Bugfix
+
+**Matcher score depended on whether `rapidfuzz` was installed** (`bug-026`):
+- `FuzzyMatcher.calculate_similarity` had two implementations — a rapidfuzz fast path returning `1 - distance / max(len)`, and a pure-Python fallback returning `(len1 + len2 - distance) / (len1 + len2)`. They disagreed: at threshold 95, `Fox Sports 1` vs `Fox Sports 2` scored **0.917** (rapidfuzz) vs **0.958** (pure-Python), flipping the match decision.
+- **Fix**: the pure-Python branch (and its early-termination bounds) now use `1 - distance / max(len)`, matching rapidfuzz exactly. Production runs the rapidfuzz path, so live behavior is unchanged — only the no-rapidfuzz fallback was corrected. `fuzzy_matcher.py` bumped to **v26.161.2350**.
+- Discovered by a new automated parity test, which now enforces the invariant.
+
+### Developer tooling
+
+- **First automated test suite** (`tests/`, 102 passing): `fuzzy_matcher` matching/normalization, `plugin.py` pure helpers (via a Django-stubbing conftest), channel-database schema validation, and version-sync. Cases are regression locks derived from the bug history.
+- **CI** (`.github/workflows/ci.yml`): py_compile + version-sync + database validation + pytest on every push/PR.
+- **Pre-commit gate** (`.githooks/pre-commit`, opt-in) and helper scripts (`scripts/check_version_sync.py`, `scripts/validate_databases.py`).
+- **`docs/DEVELOPMENT.md`**: full dev-workflow documentation.
+
+---
+
+## v1.26.1511211 (May 31, 2026)
+**Type**: Bugfix release — numeric-sibling false-positive in fuzzy matcher.
+
+### Bugfix
+
+**Same-prefix numbered channels false-match at threshold 95** (e.g. `Fox Sports 1` pulling in `Fox Sports 2` streams):
+- Under Stage 3 token-sort Levenshtein, the discriminating digit is a single-character edit. With long shared prefixes the score sails past threshold — `"1 fox sports"` vs `"2 fox sports"` is edit-distance 1 over total-length 26 = **96.15%**, above the default 95.
+- A numeric-token discriminator guard already existed inline in `plugin.py:2329` but not in the two public `FuzzyMatcher` methods, so every caller routed through `fuzzy_match` / `find_best_match` was unprotected.
+- **Fix**: mirror the guard into `fuzzy_matcher.fuzzy_match` (all three stages) and `fuzzy_matcher.find_best_match`. When the normalized query contains digit-only tokens, candidates must (a) have at least one digit token and (b) share at least one with the query. Queries without digits are unconstrained (no behavior change for the common case).
+- Math sanity: `Channel 4` vs `Channel 4K` is safe because `4K` is stripped by quality patterns before this code sees it. `ESPN 2 HD` vs `ESPN HD` (digit-asymmetric) now correctly rejects.
+
+### Notes
+- `fuzzy_matcher.py` bumped to **v26.151.1208** (was 26.095.0100).
+- **Stale data caveat**: pre-existing wrong assignments from earlier runs (ESPN2/ESPN+, C-SPAN2/C-SPAN3, FS1/FS2, Discovery Turbo +1) are not cleaned up by this fix. Run `add_streams_to_channels` with `overwrite_streams=true` to re-match and replace polluted assignments.
+- QA-reviewed (`pr-review-toolkit:code-reviewer`): zero blocking findings.
+
+---
+
 ## v1.26.1362122 (May 16, 2026)
 **Type**: Feature + bugfix release — audio-aware stream sorting (fixes GitHub #27) and profile-dropdown loading fix (fixes GitHub #26).
 

--- a/Stream-Mapparr/fuzzy_matcher.py
+++ b/Stream-Mapparr/fuzzy_matcher.py
@@ -19,7 +19,7 @@ except ImportError:
     _USE_RAPIDFUZZ = False
 
 # Version: YY.DDD.HHMM (Julian date format: Year.DayOfYear.Time)
-__version__ = "26.095.0100"
+__version__ = "26.161.2350"
 
 # Setup logging
 LOGGER = logging.getLogger("plugins.fuzzy_matcher")
@@ -664,16 +664,22 @@ class FuzzyMatcher:
             cutoff = threshold if threshold is not None else 0.0
             return _rf_lev.normalized_similarity(str1, str2, score_cutoff=cutoff)
 
-        # Pure Python fallback with optional early termination
+        # Pure Python fallback with optional early termination.
+        # bug-026: this MUST match rapidfuzz Levenshtein.normalized_similarity,
+        # which is 1 - distance / max(len). The previous formula
+        # (len1 + len2 - distance) / (len1 + len2) scored higher for the same
+        # edit distance, so results depended on whether rapidfuzz was installed
+        # (at threshold 95, "Fox Sports 1" vs "Fox Sports 2" flipped the match
+        # decision). Production runs the rapidfuzz path; this aligns the fallback.
         if len(str1) < len(str2):
             str1, str2 = str2, str1
 
-        total_len = len(str1) + len(str2)
+        max_len = len(str1)  # the longer string after the swap
 
-        # Early rejection: if strings differ in length too much, max possible
-        # similarity is bounded. Check before doing the full DP.
+        # Early rejection: the minimum possible edit distance is the length
+        # difference, so similarity can never exceed (max_len - diff) / max_len.
         if threshold is not None:
-            max_possible = (total_len - abs(len(str1) - len(str2))) / total_len
+            max_possible = (max_len - (len(str1) - len(str2))) / max_len
             if max_possible < threshold:
                 return 0.0
 
@@ -687,21 +693,20 @@ class FuzzyMatcher:
                 substitutions = previous_row[j] + (c1 != c2)
                 current_row.append(min(insertions, deletions, substitutions))
 
-            # Early termination: check if minimum possible distance in this row
-            # already makes it impossible to meet the threshold
+            # Early termination: a lower bound on the final distance is the
+            # current row minimum minus the str1 chars still unprocessed.
             if threshold is not None:
                 min_distance_so_far = min(current_row)
-                # Best case: remaining chars all match perfectly
                 remaining = len(str1) - i - 1
                 best_possible_distance = max(0, min_distance_so_far - remaining)
-                best_possible_ratio = (total_len - best_possible_distance) / total_len
+                best_possible_ratio = (max_len - best_possible_distance) / max_len
                 if best_possible_ratio < threshold:
                     return 0.0
 
             previous_row = current_row
 
         distance = previous_row[-1]
-        return (total_len - distance) / total_len
+        return (max_len - distance) / max_len
     
     def process_string_for_matching(self, s):
         """
@@ -772,14 +777,27 @@ class FuzzyMatcher:
         
         if not normalized_query:
             return None, 0
-        
+
         # Process query for token-sort matching
         processed_query = self.process_string_for_matching(normalized_query)
+
+        # Numeric-sibling guard: when the query contains digit-only tokens (e.g. "Fox Sports 1"),
+        # the discriminating digit becomes a single-char edit under token-sort Levenshtein and
+        # long shared prefixes mask it — FS1 vs FS2 scores 25/26 = 96% and slips past threshold 95.
+        # Require any candidate with digits to share at least one with the query.
+        query_digit_tokens = {t for t in normalized_query.split() if t.isdigit()}
 
         best_score = -1.0
         best_match = None
 
         for candidate in candidate_names:
+            if query_digit_tokens:
+                candidate_lower, _ = self._get_cached_norm(candidate, user_ignored_tags)
+                if candidate_lower:
+                    cand_digit_tokens = {t for t in candidate_lower.split() if t.isdigit()}
+                    if not cand_digit_tokens or not (query_digit_tokens & cand_digit_tokens):
+                        continue
+
             # Use cached processed string when available
             processed_candidate = self._get_cached_processed(candidate, user_ignored_tags)
             if not processed_candidate:
@@ -843,11 +861,17 @@ class FuzzyMatcher:
         
         if not normalized_query:
             return None, 0, None
-        
+
+        # Numeric-sibling guard: when the query contains digit-only tokens (e.g. "Fox Sports 1"),
+        # the discriminating digit becomes a single-char edit under token-sort Levenshtein and
+        # long shared prefixes mask it — FS1 vs FS2 scores 25/26 = 96% and slips past threshold 95.
+        # Mirrors the inline guard in plugin.py (~2329). Applied to every stage for defense in depth.
+        query_digit_tokens = {t for t in normalized_query.split() if t.isdigit()}
+
         best_match = None
         best_ratio = 0
         match_type = None
-        
+
         # Stage 1: Exact match (after normalization)
         normalized_query_lower = normalized_query.lower()
         normalized_query_nospace = re.sub(r'[\s&\-]+', '', normalized_query_lower)
@@ -857,6 +881,11 @@ class FuzzyMatcher:
             candidate_lower, candidate_nospace = self._get_cached_norm(candidate, user_ignored_tags)
             if not candidate_lower:
                 continue
+
+            if query_digit_tokens:
+                cand_digit_tokens = {t for t in candidate_lower.split() if t.isdigit()}
+                if not cand_digit_tokens or not (query_digit_tokens & cand_digit_tokens):
+                    continue
 
             # Exact match (space/punctuation insensitive)
             if normalized_query_nospace == candidate_nospace:
@@ -879,6 +908,11 @@ class FuzzyMatcher:
             if not candidate_lower:
                 continue
 
+            if query_digit_tokens:
+                cand_digit_tokens = {t for t in candidate_lower.split() if t.isdigit()}
+                if not cand_digit_tokens or not (query_digit_tokens & cand_digit_tokens):
+                    continue
+
             # Check if one is a substring of the other
             if normalized_query_lower in candidate_lower or candidate_lower in normalized_query_lower:
                 length_ratio = min(len(normalized_query_lower), len(candidate_lower)) / max(len(normalized_query_lower), len(candidate_lower))
@@ -900,6 +934,13 @@ class FuzzyMatcher:
         threshold_ratio = self.match_threshold / 100.0
 
         for candidate in candidate_names:
+            if query_digit_tokens:
+                candidate_lower, _ = self._get_cached_norm(candidate, user_ignored_tags)
+                if candidate_lower:
+                    cand_digit_tokens = {t for t in candidate_lower.split() if t.isdigit()}
+                    if not cand_digit_tokens or not (query_digit_tokens & cand_digit_tokens):
+                        continue
+
             # Use cached processed string when available
             processed_candidate = self._get_cached_processed(candidate, user_ignored_tags)
             if not processed_candidate:

--- a/Stream-Mapparr/plugin.json
+++ b/Stream-Mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.1362122",
+  "version": "1.26.1511211",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/Stream-Mapparr/plugin.py
+++ b/Stream-Mapparr/plugin.py
@@ -58,7 +58,7 @@ class PluginConfig:
     """
 
     # === PLUGIN METADATA ===
-    PLUGIN_VERSION = "1.26.1362122"
+    PLUGIN_VERSION = "1.26.1511211"
     FUZZY_MATCHER_MIN_VERSION = "25.358.0200"  # Requires custom ignore tags Unicode fix
 
     # Match sensitivity presets (maps select value to threshold number)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,193 @@
+# Stream-Mapparr — Development Workflow
+
+This is the single source of truth for how to develop, test, and ship
+Stream-Mapparr. It replaces the ad-hoc "manual testing" notes that used to live
+only in `CLAUDE.md`.
+
+Stream-Mapparr is a Python plugin that runs **inside Dispatcharr's Django
+backend**. There is no standalone app to launch — the plugin is loaded by
+Dispatcharr, talks to its ORM directly, and is distributed straight from this
+repo to the Plugin Hub. That shapes everything below: our safety net has to live
+in unit tests and CI because there is no staging environment between a commit and
+a user's container.
+
+---
+
+## 1. One-time setup
+
+```bash
+# from the repo root
+python -m venv .venv && . .venv/Scripts/activate   # Windows; use bin/activate on Unix
+pip install -r requirements-dev.txt
+
+# enable the pre-commit gate (compile + version sync + db validate + fast tests)
+git config core.hooksPath .githooks
+```
+
+> **Why no Django in requirements?** Django, `pytz`, and the Dispatcharr ORM
+> (`apps.channels.models`, `core.utils`) are provided by the Dispatcharr runtime.
+> The test suite stubs them (see `tests/conftest.py`) so `plugin.py` can be
+> imported in isolation. `rapidfuzz` is optional at runtime but **required for
+> tests** so CI can exercise both matching code paths.
+
+---
+
+## 2. The inner loop
+
+```
+edit code  ->  pytest  ->  deploy to container  ->  watch logs
+```
+
+### Run the tests
+
+```bash
+python -m pytest -q                 # everything (~0.5s)
+python -m pytest tests/test_fuzzy_matcher.py -q     # just the matcher
+python -m pytest -k probe_fresh -q                  # one behavior
+```
+
+### Verify before deploy
+
+```bash
+python -m py_compile Stream-Mapparr/plugin.py Stream-Mapparr/fuzzy_matcher.py
+python scripts/check_version_sync.py
+python scripts/validate_databases.py
+```
+
+### Deploy to Dispatcharr
+
+Use the **`/deploy-plugin`** skill, or do it by hand. The critical rule:
+
+> **Dispatcharr hot-reloads on `plugin.json` mtime, NOT `plugin.py`.**
+> Always bump the version (which touches `plugin.json`) and copy **both** files,
+> or the old module stays in memory and you debug a build that isn't running.
+
+```bash
+python Stream-Mapparr/bump_version.py
+docker cp Stream-Mapparr/plugin.py   dispatcharr:/data/plugins/stream-mapparr/
+docker cp Stream-Mapparr/plugin.json dispatcharr:/data/plugins/stream-mapparr/
+docker logs --tail 50 dispatcharr | grep -i stream-mapparr   # confirm new version is live
+```
+
+A background thread started under the old code keeps running the old code until
+it exits — fresh deploys only affect new invocations.
+
+---
+
+## 3. The test suite
+
+Located in `tests/`. Most cases are **regression locks derived from real bugs**
+(`.wolf/buglog.json`, the `BUG_REPORT_*.md` files). When you fix a bug, add the
+case that would have caught it.
+
+| File | Covers | Needs Django stub? |
+|---|---|---|
+| `test_fuzzy_matcher.py` | normalization, similarity, callsign extraction, the numeric-sibling guard (bug-021), zone expansion | No — pure stdlib + rapidfuzz |
+| `test_plugin_helpers.py` | `_parse_tags`, `_parse_priority_list`, `_audio_rank`, `_is_probe_fresh` (bug-008) | Yes (via conftest) |
+| `test_databases.py` | schema of every `*_channels.json` (the US file is 3.6 MB) | No |
+| `test_version_sync.py` | `plugin.json` version == `PLUGIN_VERSION`, calver format | No |
+
+### How importing `plugin.py` works in tests
+
+`plugin.py` imports Django and the Dispatcharr ORM at module load. `conftest.py`
+installs lightweight stubs into `sys.modules` (a fake `django.utils.timezone.now`,
+`MagicMock` ORM models, etc.) and loads the plugin as a package submodule so its
+relative imports (`from .fuzzy_matcher import FuzzyMatcher`) resolve. You never
+need a configured Django to run the suite.
+
+Test only **pure** helpers this way (no DB/HTTP/ORM side effects). For instance
+methods that need no instance state, `Plugin.__new__(Plugin)` gives you a bare
+object without running `__init__`.
+
+### Matcher path parity — `bug-026` (fixed 2026-06-10)
+
+`calculate_similarity` has two implementations: a rapidfuzz fast path and a
+pure-Python fallback. They previously used *different* normalization formulas, so
+results depended on whether `rapidfuzz` was installed — at threshold 95,
+"Fox Sports 1" vs "Fox Sports 2" scored 0.917 (rapidfuzz) vs 0.958 (pure-Python),
+flipping the match decision.
+
+Both now return `1 - distance / max(len)`. Production runs the rapidfuzz path, so
+live behavior didn't change — only the fallback was corrected to agree.
+`test_rapidfuzz_and_pure_python_agree` enforces this going forward; if you ever
+touch the similarity math, that test must stay green.
+
+> Note: when `calculate_similarity` is called *with* a `threshold`, the two paths
+> can still return different numeric values for scores **below** the cutoff
+> (rapidfuzz zeroes them; the fallback may return the low score). That's harmless
+> — every caller compares `>= threshold`, so match decisions and all kept scores
+> are identical. The parity test deliberately checks the unthresholded score.
+
+---
+
+## 4. Continuous integration
+
+`.github/workflows/ci.yml` runs on every push to `main`, every PR, and manual
+dispatch. It is the only gate between a commit and a user pulling broken code.
+
+Steps: install dev deps → byte-compile both modules → version sync → database
+validation → `pytest`. Byte-compilation works without Django because compiling
+does not execute imports.
+
+The pre-commit hook (`.githooks/pre-commit`) runs a fast subset locally so most
+failures are caught before they ever reach CI.
+
+---
+
+## 5. Releasing
+
+Use the **`/release`** skill for the full checklist. Summary of the house style:
+
+- **Version scheme:** calver `1.MAJOR.DDDHHMM` (UTC day-of-year + HHMM). Always
+  bump with `Stream-Mapparr/bump_version.py` so `plugin.py` and `plugin.json`
+  stay in lockstep.
+- **Release tag:** bare calver, **no `v` prefix** (e.g. `1.26.1611423`).
+- **End-to-end means end-to-end:** push, tagged GitHub release with the zip
+  attached, comment + close the resolved issues, update **all** docs
+  (`CHANGELOG.md`, `README.md`, `CLAUDE.md` current-version line), and deploy to
+  the container. Stale version strings in docs are a recurring bug class — grep
+  for the old version before you finish.
+
+---
+
+## 6. Conventions & gotchas (the short list)
+
+- **`_parse_tags` is the canonical comma-list parser** (quote-aware). New
+  comma-separated settings should delegate to it, not hand-roll `split(',')`.
+- **Dispatcharr rejects blank field option values** — a dynamic option with
+  `{"value": ""}` makes the serializer silently drop the *entire* field. Use a
+  non-blank sentinel (`_none`) and normalize it back to `""` at every read site
+  (bug-020).
+- **`M3UAccount.user_agent` is a ForeignKey**, not a string — dig into
+  `.user_agent / .value / .string / .name` (bug-007).
+- **Failed throughput probes (`throughput_mbps is None`) are never "fresh"** —
+  otherwise a bad run locks out re-probing for a TTL window (bug-008).
+- **Don't use `django.utils.timezone.utc`** (removed in Django 5.0). Use
+  `timezone.now()` or the stdlib `dt_timezone.utc` alias (bug-006).
+
+---
+
+## 7. Repo map for developers
+
+```
+Stream-Mapparr/
+  plugin.py            # main plugin (~260 KB) — Plugin class, actions, ORM, scheduler, probe
+  fuzzy_matcher.py     # matching library — no Django dependency, unit-test heaven
+  bump_version.py      # version sync tool (run before every deploy/release)
+  *_channels.json      # per-country channel databases (US is 3.6 MB)
+tests/                 # pytest suite (this doc, section 3)
+scripts/
+  check_version_sync.py    # CI/hook: plugin.json == plugin.py
+  validate_databases.py    # CI/hook: channel DB schema
+.github/workflows/ci.yml   # CI pipeline
+.githooks/pre-commit       # local fast gate (opt in with core.hooksPath)
+docs/DEVELOPMENT.md        # you are here
+```
+
+### Backlog / not yet done
+
+- `plugin.py` at ~260 KB is past the size where edits are safe by eye. Once the
+  test suite has grown, split the probe / scheduler / sort concerns into modules.
+- The ~50 historical `CHANGELOG_v*.md` / `QUICK_SUMMARY_*.md` / `BUG_REPORT_*.md`
+  files duplicate the consolidated `Stream-Mapparr/CHANGELOG.md`; archive them
+  under `docs/history/` and stop generating per-version files.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -ra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,12 @@
+# Development / CI dependencies for Stream-Mapparr.
+#
+# NOTE: Django, pytz, and the Dispatcharr ORM (apps.channels.models, core.utils)
+# are provided by the Dispatcharr runtime, NOT installed here. The test suite
+# stubs them (see tests/conftest.py) so plugin.py can be imported in isolation.
+#
+# Runtime note: rapidfuzz is OPTIONAL in production (fuzzy_matcher falls back to
+# a pure-Python Levenshtein when it is absent). It is required here so CI can
+# exercise BOTH code paths and assert they agree.
+
+pytest>=8.0
+rapidfuzz>=3.0

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Fail if plugin.json version != PLUGIN_VERSION in plugin.py.
+
+Shared by CI and the pre-commit hook. Exits non-zero on drift so a mismatched
+build can never be committed or merged. Dispatcharr hot-reloads on plugin.json
+mtime, so a drifted version means the UI advertises one build while another runs.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent / "Stream-Mapparr"
+
+
+def main() -> int:
+    plugin_json = PLUGIN_DIR / "plugin.json"
+    plugin_py = PLUGIN_DIR / "plugin.py"
+
+    json_version = json.loads(plugin_json.read_text(encoding="utf-8"))["version"]
+
+    m = re.search(r'PLUGIN_VERSION\s*=\s*["\']([^"\']+)["\']',
+                  plugin_py.read_text(encoding="utf-8"))
+    if not m:
+        print("ERROR: PLUGIN_VERSION not found in plugin.py", file=sys.stderr)
+        return 2
+    code_version = m.group(1)
+
+    if json_version != code_version:
+        print(f"VERSION DRIFT: plugin.json={json_version!r} != "
+              f"plugin.py={code_version!r}\n"
+              f"  -> run: python Stream-Mapparr/bump_version.py", file=sys.stderr)
+        return 1
+
+    print(f"version OK: {json_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_databases.py
+++ b/scripts/validate_databases.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Validate every *_channels.json against the structure the loader relies on.
+
+Standalone (no pytest) so it can run in CI and the pre-commit hook even on a
+machine without the dev deps. Mirrors the rules in tests/test_databases.py.
+Exits non-zero (and prints every problem) if any database is malformed.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent / "Stream-Mapparr"
+BROADCAST_MARKER = "broadcast"
+
+
+def validate_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        return [f"{path.name}: cannot parse JSON: {e}"]
+
+    if not isinstance(data, dict) or not isinstance(data.get("channels"), list):
+        return [f"{path.name}: top level must be an object with a 'channels' array"]
+    if not data["channels"]:
+        errors.append(f"{path.name}: 'channels' is empty")
+    if not str(data.get("country_code", "")).strip():
+        errors.append(f"{path.name}: missing 'country_code'")
+
+    for i, c in enumerate(data["channels"]):
+        ctype = str(c.get("type", "")).lower()
+        if not ctype.strip():
+            errors.append(f"{path.name}[{i}]: missing 'type'")
+        if BROADCAST_MARKER in ctype:
+            if not str(c.get("callsign", "")).strip():
+                errors.append(f"{path.name}[{i}]: broadcast channel missing 'callsign'")
+        else:
+            if not str(c.get("channel_name", "")).strip():
+                errors.append(f"{path.name}[{i}]: premium channel missing 'channel_name'")
+        if "zones" in c:
+            z = c["zones"]
+            if not isinstance(z, list) or not z or any(not str(v).strip() for v in z):
+                errors.append(f"{path.name}[{i}]: 'zones' must be a non-empty list of non-empty strings")
+    return errors
+
+
+def main() -> int:
+    files = sorted(PLUGIN_DIR.glob("*_channels.json"))
+    if not files:
+        print("ERROR: no *_channels.json files found", file=sys.stderr)
+        return 2
+
+    all_errors: list[str] = []
+    for path in files:
+        errs = validate_file(path)
+        all_errors.extend(errs)
+        print(f"{'FAIL' if errs else 'ok  '}  {path.name}"
+              + (f"  ({len(errs)} problem(s))" if errs else ""))
+
+    if all_errors:
+        print(f"\n{len(all_errors)} problem(s):", file=sys.stderr)
+        for e in all_errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(f"\nall {len(files)} database(s) valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,136 @@
+"""Shared test fixtures for Stream-Mapparr.
+
+The plugin runs *inside* Dispatcharr's Django backend, so plugin.py imports
+Django, pytz, and the Dispatcharr ORM at module load. None of that is available
+in a bare CI checkout. This conftest installs lightweight stubs for those
+modules so the plugin can be imported and its pure helpers tested in isolation.
+
+fuzzy_matcher.py has NO Django dependency (stdlib + optional rapidfuzz only), so
+it is loaded directly from its file path with no stubbing required.
+"""
+
+import importlib.util
+import sys
+import types
+from datetime import datetime, timezone as _stdlib_tz
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Repo layout: <root>/Stream-Mapparr/{plugin.py,fuzzy_matcher.py,*_channels.json}
+PLUGIN_DIR = Path(__file__).resolve().parent.parent / "Stream-Mapparr"
+_PKG = "stream_mapparr_under_test"
+
+
+def _install_runtime_stubs():
+    """Inject fake django / apps / core / pytz modules into sys.modules.
+
+    Installed unconditionally (overwriting any real Django) so tests never
+    depend on a configured Django settings module.
+    """
+    # --- pytz: prefer the real package, fall back to a minimal stub ---
+    if "pytz" not in sys.modules:
+        try:  # pragma: no cover - depends on environment
+            import pytz  # noqa: F401
+        except ImportError:
+            pytz_stub = types.ModuleType("pytz")
+            pytz_stub.utc = _stdlib_tz.utc
+            pytz_stub.timezone = lambda name: _stdlib_tz.utc
+            pytz_stub.all_timezones = []
+            sys.modules["pytz"] = pytz_stub
+
+    # --- django.utils.timezone / django.db.transaction ---
+    django = types.ModuleType("django")
+    django_utils = types.ModuleType("django.utils")
+    django_tz = types.ModuleType("django.utils.timezone")
+    django_tz.now = lambda: datetime.now(_stdlib_tz.utc)  # aware UTC, like Django USE_TZ
+    django_utils.timezone = django_tz
+    django_db = types.ModuleType("django.db")
+    django_db.transaction = MagicMock(name="transaction")
+    sys.modules.update({
+        "django": django,
+        "django.utils": django_utils,
+        "django.utils.timezone": django_tz,
+        "django.db": django_db,
+    })
+
+    # --- apps.channels.models (Dispatcharr ORM) ---
+    apps = types.ModuleType("apps"); apps.__path__ = []
+    apps_channels = types.ModuleType("apps.channels"); apps_channels.__path__ = []
+    models = types.ModuleType("apps.channels.models")
+    for name in ("Channel", "ChannelGroup", "ChannelProfile",
+                 "ChannelProfileMembership", "ChannelStream", "Stream"):
+        setattr(models, name, MagicMock(name=name))
+    sys.modules.update({
+        "apps": apps,
+        "apps.channels": apps_channels,
+        "apps.channels.models": models,
+    })
+
+    # --- core.utils.send_websocket_update ---
+    core = types.ModuleType("core"); core.__path__ = []
+    core_utils = types.ModuleType("core.utils")
+    core_utils.send_websocket_update = MagicMock(name="send_websocket_update")
+    sys.modules.update({"core": core, "core.utils": core_utils})
+
+
+def _load_from_path(module_name, file_name):
+    spec = importlib.util.spec_from_file_location(module_name, PLUGIN_DIR / file_name)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_fuzzy_matcher():
+    """Import fuzzy_matcher.py directly (no package context needed)."""
+    name = f"{_PKG}_fuzzy_matcher"
+    if name not in sys.modules:
+        _load_from_path(name, "fuzzy_matcher.py")
+    return sys.modules[name]
+
+
+def load_plugin():
+    """Import plugin.py as a package submodule so its relative imports resolve.
+
+    plugin.py does `from .fuzzy_matcher import FuzzyMatcher`, which only works if
+    it is loaded as a member of a package whose __path__ points at PLUGIN_DIR.
+    """
+    _install_runtime_stubs()
+    if _PKG not in sys.modules:
+        pkg = types.ModuleType(_PKG)
+        pkg.__path__ = [str(PLUGIN_DIR)]
+        sys.modules[_PKG] = pkg
+    if f"{_PKG}.fuzzy_matcher" not in sys.modules:
+        _load_from_path(f"{_PKG}.fuzzy_matcher", "fuzzy_matcher.py")
+    if f"{_PKG}.plugin" not in sys.modules:
+        _load_from_path(f"{_PKG}.plugin", "plugin.py")
+    return sys.modules[f"{_PKG}.plugin"]
+
+
+@pytest.fixture(scope="session")
+def fuzzy_module():
+    return load_fuzzy_matcher()
+
+
+@pytest.fixture(scope="session")
+def plugin_module():
+    return load_plugin()
+
+
+@pytest.fixture
+def matcher(fuzzy_module, tmp_path):
+    """A FuzzyMatcher with NO channel databases loaded (fast, deterministic).
+
+    Pointing plugin_dir at an empty tmp dir skips loading the multi-MB real
+    *_channels.json files, which the unit tests don't need.
+    """
+    def _make(threshold=85):
+        return fuzzy_module.FuzzyMatcher(plugin_dir=str(tmp_path), match_threshold=threshold)
+    return _make
+
+
+def channel_db_files():
+    """All *_channels.json paths in the plugin dir (used to parametrize tests)."""
+    return sorted(PLUGIN_DIR.glob("*_channels.json"))

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,0 +1,90 @@
+"""Schema validation for the *_channels.json country databases.
+
+The US file alone is ~3.6 MB; a malformed hand-edit currently surfaces only at
+runtime inside Dispatcharr. These tests catch structural breakage at commit/CI
+time. The rules mirror what FuzzyMatcher._load_channel_databases actually relies
+on, so a passing suite means the loader will not silently drop channels.
+"""
+
+import json
+
+import pytest
+
+from conftest import channel_db_files
+
+DB_FILES = channel_db_files()
+DB_IDS = [p.name for p in DB_FILES]
+
+VALID_BROADCAST_MARKER = "broadcast"  # type contains this -> OTA channel (needs callsign)
+
+
+@pytest.fixture(scope="module", params=DB_FILES, ids=DB_IDS)
+def db(request):
+    with open(request.param, encoding="utf-8") as f:
+        data = json.load(f)  # raises -> test fails on invalid JSON
+    return request.param.name, data
+
+
+def test_has_channels_list(db):
+    name, data = db
+    assert isinstance(data, dict), f"{name}: top level must be an object"
+    assert isinstance(data.get("channels"), list), f"{name}: missing 'channels' array"
+    assert data["channels"], f"{name}: 'channels' is empty"
+
+
+def test_country_code_present(db):
+    name, data = db
+    # Filename is the contract (US_channels.json -> US); the field should agree.
+    code = data.get("country_code")
+    assert code, f"{name}: missing 'country_code'"
+    assert name.upper().startswith(str(code).upper()), \
+        f"{name}: country_code {code!r} does not match filename"
+
+
+def test_every_channel_has_type(db):
+    name, data = db
+    missing = [i for i, c in enumerate(data["channels"]) if not str(c.get("type", "")).strip()]
+    assert not missing, f"{name}: {len(missing)} channel(s) missing 'type' (first idx {missing[:3]})"
+
+
+def test_premium_channels_have_names(db):
+    """Non-OTA channels must carry a non-empty channel_name (loader drops blanks)."""
+    name, data = db
+    bad = []
+    for i, c in enumerate(data["channels"]):
+        ctype = str(c.get("type", "")).lower()
+        if VALID_BROADCAST_MARKER in ctype:
+            continue
+        if not str(c.get("channel_name", "")).strip():
+            bad.append(i)
+    assert not bad, f"{name}: {len(bad)} premium channel(s) with blank channel_name (first {bad[:3]})"
+
+
+def test_broadcast_channels_have_callsigns(db):
+    """OTA channels are matched purely by callsign — a blank one is unreachable."""
+    name, data = db
+    bad = []
+    for i, c in enumerate(data["channels"]):
+        if VALID_BROADCAST_MARKER in str(c.get("type", "")).lower():
+            if not str(c.get("callsign", "")).strip():
+                bad.append(i)
+    assert not bad, f"{name}: {len(bad)} broadcast channel(s) missing 'callsign' (first {bad[:3]})"
+
+
+def test_zones_field_is_nonempty_string_list(db):
+    """If 'zones' is present it must be a list of non-empty strings (else _expand_zones warns/skips)."""
+    name, data = db
+    bad = []
+    for i, c in enumerate(data["channels"]):
+        if "zones" not in c:
+            continue
+        zones = c["zones"]
+        if not isinstance(zones, list) or not zones or \
+                any(not str(z).strip() for z in zones):
+            bad.append((i, zones))
+    assert not bad, f"{name}: malformed 'zones' on {len(bad)} channel(s): {bad[:3]}"
+
+
+def test_at_least_one_database_present():
+    """Guard against the glob silently finding nothing (e.g. wrong CWD in CI)."""
+    assert DB_FILES, "no *_channels.json files found next to plugin.py"

--- a/tests/test_fuzzy_matcher.py
+++ b/tests/test_fuzzy_matcher.py
@@ -1,0 +1,182 @@
+"""Regression tests for fuzzy_matcher.py.
+
+Most cases are derived directly from documented bugs in .wolf/buglog.json and the
+BUG_REPORT_*.md files — each one locks in a fix that was shipped at least once.
+fuzzy_matcher has no Django dependency, so these run with just pytest (+ rapidfuzz
+to exercise the fast path).
+"""
+
+import importlib
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# normalize_name — tag stripping
+# --------------------------------------------------------------------------- #
+
+def test_quality_tag_stripped(matcher):
+    m = matcher()
+    assert m.normalize_name("CNN HD").upper().strip() == "CNN"
+    assert "4K" not in m.normalize_name("CNN 4K").upper()
+    assert "FHD" not in m.normalize_name("ESPN [FHD]").upper()
+
+
+def test_itv1_and_itv_space_1_normalize_identically(matcher):
+    """'ITV1' and 'ITV 1' must collapse to the same form (digit-spacing fix)."""
+    m = matcher()
+    assert m.normalize_name("ITV1") == m.normalize_name("ITV 1")
+
+
+def test_regional_west_stripped_when_enabled(matcher):
+    """BUGFIX_Regional_Tags_West_Missing: 'West' must be removed under strip_all."""
+    m = matcher()
+    assert "WEST" not in m.normalize_name("FX West", ignore_regional=True).upper()
+
+
+def test_regional_west_kept_when_disabled(matcher):
+    """Keep-Regional handling must preserve 'West' so East/West stay distinct."""
+    m = matcher()
+    assert "WEST" in m.normalize_name("FX West", ignore_regional=False).upper()
+
+
+def test_unicode_user_ignore_tag_does_not_crash(matcher):
+    """BUG_REPORT_Custom_Ignore_Tags_Unicode: box-drawing tags broke \\b word boundaries."""
+    m = matcher()
+    out = m.normalize_name("Sport ┃NLZIET┃", user_ignored_tags=["┃NLZIET┃"])
+    assert "NLZIET" not in out
+    assert "Sport" in out
+
+
+def test_word_boundary_tag_does_not_strip_substring(matcher):
+    """'East' as an ignore tag must not nuke the 'east' inside 'Feast'."""
+    m = matcher()
+    out = m.normalize_name("Feast", user_ignored_tags=["East"], ignore_regional=False)
+    assert "Feast" in out
+
+
+# --------------------------------------------------------------------------- #
+# calculate_similarity
+# --------------------------------------------------------------------------- #
+
+def test_similarity_identical_and_empty(matcher):
+    m = matcher()
+    assert m.calculate_similarity("cnn", "cnn") == 1.0
+    assert m.calculate_similarity("", "cnn") == 0.0
+    assert m.calculate_similarity("cnn", "") == 0.0
+
+
+def test_similarity_threshold_early_out(matcher):
+    """When lengths differ too much to ever meet the threshold, return 0.0."""
+    m = matcher()
+    assert m.calculate_similarity("a", "abcdefghij", threshold=0.9) == 0.0
+
+
+def test_rapidfuzz_and_pure_python_agree(fuzzy_module, matcher):
+    """The optional C path and the pure-Python fallback must return the same score.
+
+    bug-026 fix: both now use 1 - distance / max(len). A divergence here would
+    make results depend on whether rapidfuzz is installed. Skips if rapidfuzz
+    isn't present (nothing to compare against).
+    """
+    if not fuzzy_module._USE_RAPIDFUZZ:
+        pytest.skip("rapidfuzz not installed; only one path available")
+
+    pairs = [("fox sports 1", "fox sports 2"),
+             ("cnn", "cnn hd"),
+             ("discovery channel", "discovery"),
+             ("bbc one", "bbc two")]
+    m = matcher()
+
+    fast = [m.calculate_similarity(a, b) for a, b in pairs]
+    fuzzy_module._USE_RAPIDFUZZ = False
+    try:
+        slow = [m.calculate_similarity(a, b) for a, b in pairs]
+    finally:
+        fuzzy_module._USE_RAPIDFUZZ = True
+
+    for (a, b), f, s in zip(pairs, fast, slow):
+        assert f == pytest.approx(s, abs=1e-9), f"path divergence on {a!r} vs {b!r}: {f} != {s}"
+
+
+# --------------------------------------------------------------------------- #
+# process_string_for_matching
+# --------------------------------------------------------------------------- #
+
+def test_token_sort_is_order_insensitive(matcher):
+    m = matcher()
+    assert m.process_string_for_matching("Sports Fox") == m.process_string_for_matching("Fox Sports")
+
+
+def test_accents_folded(matcher):
+    m = matcher()
+    assert m.process_string_for_matching("Canalé") == m.process_string_for_matching("Canale")
+
+
+# --------------------------------------------------------------------------- #
+# extract_callsign
+# --------------------------------------------------------------------------- #
+
+def test_callsign_from_parenthetical_suffix(matcher):
+    """Priority-1 regex captures the base callsign stem; the loader also stores the
+    '-TV' form, so resolving by either key works. Base form is what's returned."""
+    m = matcher()
+    assert m.extract_callsign("WABC New York (WABC-TV)") == "WABC"
+
+
+def test_regional_word_not_mistaken_for_callsign(matcher):
+    """'(WEST)' looks like a K/W callsign but must be rejected as a false positive."""
+    m = matcher()
+    assert m.extract_callsign("Some Channel (WEST)") != "WEST"
+
+
+# --------------------------------------------------------------------------- #
+# Numeric-sibling guard (bug-021: Fox Sports 1 vs Fox Sports 2)
+# --------------------------------------------------------------------------- #
+
+def test_numeric_siblings_do_not_false_match(matcher):
+    """At threshold 95, 'Fox Sports 2' must NOT match candidate 'Fox Sports 1'."""
+    m = matcher(threshold=95)
+    name, score, mtype = m.fuzzy_match("Fox Sports 2", ["Fox Sports 1"])
+    assert name is None and score == 0
+
+
+def test_numeric_sibling_correct_match_still_works(matcher):
+    """The guard must not block the correct same-number match."""
+    m = matcher(threshold=95)
+    name, score, _ = m.fuzzy_match("Fox Sports 1", ["Fox Sports 1", "Fox Sports 2"])
+    assert name == "Fox Sports 1"
+    assert score == 100
+
+
+def test_find_best_match_respects_numeric_guard(matcher):
+    m = matcher(threshold=95)
+    name, score = m.find_best_match("ESPN 2", ["ESPN 3"])
+    assert name is None and score == 0
+
+
+# --------------------------------------------------------------------------- #
+# _expand_zones
+# --------------------------------------------------------------------------- #
+
+def test_expand_zones_emits_variants_not_base(matcher):
+    """A zoned premium channel yields 'FX East'/'FX West' but NOT bare 'FX'."""
+    m = matcher()
+    names = [c["channel_name"] for c in m._expand_zones(
+        {"channel_name": "FX", "type": "premium/cable/national", "zones": ["East", "West"]})]
+    assert names == ["FX East", "FX West"]
+    assert "FX" not in names
+
+
+def test_expand_zones_passthrough_without_zones(matcher):
+    m = matcher()
+    out = list(m._expand_zones({"channel_name": "CNN", "type": "premium/cable/national"}))
+    assert len(out) == 1 and out[0]["channel_name"] == "CNN"
+
+
+def test_expand_zones_malformed_zones_treated_as_unzoned(matcher):
+    """A non-list 'zones' must degrade gracefully, not raise."""
+    m = matcher()
+    out = list(m._expand_zones({"channel_name": "TNT", "type": "premium", "zones": "East"}))
+    assert len(out) == 1 and out[0]["channel_name"] == "TNT"
+    assert "zones" not in out[0]

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -1,0 +1,121 @@
+"""Tests for pure helpers in plugin.py.
+
+plugin.py imports Django + the Dispatcharr ORM at module load, so conftest stubs
+those before import. We exercise the genuinely pure helpers — the ones whose past
+breakage is recorded in .wolf/buglog.json / cerebrum Do-Not-Repeat.
+"""
+
+from datetime import datetime, timedelta, timezone as dt_tz
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# _parse_tags — the canonical quote-aware comma parser
+# --------------------------------------------------------------------------- #
+
+def test_parse_tags_basic(plugin_module):
+    Plugin = plugin_module.Plugin
+    assert Plugin._parse_tags("a, b ,c") == ["a", "b", "c"]
+
+
+def test_parse_tags_empty(plugin_module):
+    Plugin = plugin_module.Plugin
+    assert Plugin._parse_tags("") == []
+    assert Plugin._parse_tags("   ") == []
+    assert Plugin._parse_tags(None) == []
+
+
+def test_parse_tags_quoted_comma_is_literal(plugin_module):
+    Plugin = plugin_module.Plugin
+    assert Plugin._parse_tags('"a, b", c') == ["a, b", "c"]
+
+
+def test_parse_tags_drops_empties(plugin_module):
+    Plugin = plugin_module.Plugin
+    assert Plugin._parse_tags("a,,b,") == ["a", "b"]
+
+
+# --------------------------------------------------------------------------- #
+# _parse_priority_list — lowercased delegation to _parse_tags
+# --------------------------------------------------------------------------- #
+
+def test_parse_priority_list_lowercases(plugin_module):
+    Plugin = plugin_module.Plugin
+    assert Plugin._parse_priority_list("EAC3, AC3") == ["eac3", "ac3"]
+
+
+def test_parse_priority_list_empty_inputs(plugin_module):
+    Plugin = plugin_module.Plugin
+    assert Plugin._parse_priority_list("") == []
+    assert Plugin._parse_priority_list(None) == []
+
+
+# --------------------------------------------------------------------------- #
+# _audio_rank — empty list no-op, substring match, unlisted=worst
+# --------------------------------------------------------------------------- #
+
+def test_audio_rank_empty_list_is_noop(plugin_module):
+    Plugin = plugin_module.Plugin
+    assert Plugin._audio_rank("5.1", []) == 0
+    assert Plugin._audio_rank(None, []) == 0
+
+
+def test_audio_rank_returns_index(plugin_module):
+    Plugin = plugin_module.Plugin
+    pri = ["5.1", "stereo"]
+    assert Plugin._audio_rank("5.1", pri) == 0
+    assert Plugin._audio_rank("stereo", pri) == 1
+
+
+def test_audio_rank_substring_match(plugin_module):
+    """ffprobe emits both '5.1' and '5.1(side)' for one layout -> substring, not exact."""
+    Plugin = plugin_module.Plugin
+    assert Plugin._audio_rank("5.1(side)", ["5.1"]) == 0
+
+
+def test_audio_rank_unlisted_and_missing_sort_last(plugin_module):
+    Plugin = plugin_module.Plugin
+    pri = ["5.1", "stereo"]
+    assert Plugin._audio_rank("mono", pri) == len(pri)
+    assert Plugin._audio_rank(None, pri) == len(pri)
+    assert Plugin._audio_rank("", pri) == len(pri)
+
+
+# --------------------------------------------------------------------------- #
+# _is_probe_fresh — failed probes (null mbps) are NEVER fresh (bug-008)
+# --------------------------------------------------------------------------- #
+
+def _bare_plugin(plugin_module):
+    """A Plugin instance without running __init__ (the helper needs no state)."""
+    return plugin_module.Plugin.__new__(plugin_module.Plugin)
+
+
+def test_probe_fresh_recent_real_measurement(plugin_module):
+    p = _bare_plugin(plugin_module)
+    now = datetime.now(dt_tz.utc)
+    entry = {"throughput_mbps": 12.3, "throughput_measured_at": now.isoformat()}
+    assert p._is_probe_fresh(entry, ttl_minutes=30) is True
+
+
+def test_probe_with_null_mbps_is_never_fresh(plugin_module):
+    """bug-008: a fresh timestamp + null mbps must NOT block re-probing."""
+    p = _bare_plugin(plugin_module)
+    now = datetime.now(dt_tz.utc)
+    entry = {"throughput_mbps": None, "throughput_measured_at": now.isoformat()}
+    assert p._is_probe_fresh(entry, ttl_minutes=30) is False
+
+
+def test_probe_expired_is_not_fresh(plugin_module):
+    p = _bare_plugin(plugin_module)
+    old = datetime.now(dt_tz.utc) - timedelta(minutes=45)
+    entry = {"throughput_mbps": 5.0, "throughput_measured_at": old.isoformat()}
+    assert p._is_probe_fresh(entry, ttl_minutes=30) is False
+
+
+def test_probe_missing_or_malformed_entry(plugin_module):
+    p = _bare_plugin(plugin_module)
+    assert p._is_probe_fresh(None, ttl_minutes=30) is False
+    assert p._is_probe_fresh({}, ttl_minutes=30) is False
+    assert p._is_probe_fresh(
+        {"throughput_mbps": 5.0, "throughput_measured_at": "not-a-date"}, 30) is False

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,38 @@
+"""plugin.json version MUST equal PLUGIN_VERSION in plugin.py.
+
+This drift is a documented failure mode: Dispatcharr hot-reloads on plugin.json
+mtime, so a version that disagrees with the code means the UI advertises one
+build while another runs. bump_version.py keeps them in sync; this test fails
+loudly if a hand-edit breaks that.
+"""
+
+import json
+import re
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent / "Stream-Mapparr"
+
+
+def _json_version():
+    with open(PLUGIN_DIR / "plugin.json", encoding="utf-8") as f:
+        return json.load(f)["version"]
+
+
+def _code_version():
+    text = (PLUGIN_DIR / "plugin.py").read_text(encoding="utf-8")
+    m = re.search(r'PLUGIN_VERSION\s*=\s*["\']([^"\']+)["\']', text)
+    assert m, "PLUGIN_VERSION assignment not found in plugin.py"
+    return m.group(1)
+
+
+def test_versions_match():
+    assert _json_version() == _code_version(), (
+        f"version drift: plugin.json={_json_version()!r} "
+        f"plugin.py={_code_version()!r} — run bump_version.py"
+    )
+
+
+def test_version_is_calver():
+    """Bare calver 1.MAJOR.DDDHHMM, no 'v' prefix (matches release tag style)."""
+    assert re.fullmatch(r"1\.\d+\.\d+", _json_version()), \
+        f"{_json_version()!r} is not bare calver 1.MAJOR.DDDHHMM"


### PR DESCRIPTION
## Summary

Adds the project's first automated test suite, CI, and developer tooling — plus a matcher correctness fix surfaced by the new tests. The repo is the Dispatcharr Plugin Hub distribution source, so this establishes a safety net between commits and users pulling code.

## Commits

**`release: v1.26.1511211 + bug-026 matcher path parity fix`**
- Commits the previously-uncommitted v1.26.1511211 release (version bumps + the bug-021 numeric-sibling guard for same-prefix numbered channels).
- **bug-026 fix:** `FuzzyMatcher.calculate_similarity` returned different scores depending on whether `rapidfuzz` was installed — rapidfuzz uses `1 - distance/max(len)`, the pure-Python fallback used `(len1+len2-distance)/(len1+len2)`. At threshold 95 this flipped the match decision (`Fox Sports 1` vs `Fox Sports 2`: 0.917 vs 0.958). The fallback now matches rapidfuzz exactly. Production runs the rapidfuzz path, so live behavior is unchanged — only the no-rapidfuzz fallback was corrected. `fuzzy_matcher` bumped to `26.161.2350`.

**`test: add automated test suite, CI, pre-commit gate, and dev docs`**
- **`tests/`** (102 passing): fuzzy matching/normalization, `plugin.py` pure helpers (via a Django-stubbing `conftest.py`), channel-database schema validation, and version sync. Cases are regression locks derived from the documented bug history.
- **`.github/workflows/ci.yml`:** py_compile + version-sync + database validation + pytest on every push/PR.
- **`.githooks/pre-commit`:** fast local gate (opt in via `git config core.hooksPath .githooks`).
- **`scripts/`:** standalone version-sync and database validators, shared by CI and the hook.
- **`docs/DEVELOPMENT.md`:** full dev-workflow documentation.
- **`.gitignore` / `.gitattributes`:** track `requirements-dev.txt`, ignore per-version doc sprawl + the local `docs/history/` archive, force LF on the shell hook.

## Test plan

- `pip install -r requirements-dev.txt`
- `python -m pytest -q` -> **102 passed**
- `python scripts/check_version_sync.py` and `python scripts/validate_databases.py` -> pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
