### PR TITLE
ci: make validate_zip.py project-agnostic (auto-detect package root)

### DIFF
--- a/scripts/validate_zip.py
+++ b/scripts/validate_zip.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-r"""Validate a Stream-Mapparr release zip before upload.
+r"""Validate a Dispatcharr-plugin release zip before upload.
 
 Guards against the bug-087 class of packaging failures: a zip built with
 PowerShell `Compress-Archive` / .NET Framework `ZipFile.CreateFromDirectory`
@@ -8,26 +8,30 @@ forward slashes; on a Linux host these names are treated as flat literal
 filenames, so Dispatcharr's install fails with
 "missing plugin.py or package __init__.py".
 
-IMPORTANT: Python's own `zipfile.namelist()` normalizes `\` -> `/` on read,
-so it CANNOT detect this — check (a) parses the raw central-directory bytes.
+IMPORTANT: Python's own `zipfile.namelist()` normalizes `\` -> `/` on read, so
+it CANNOT detect this — check (a) parses the raw central-directory bytes.
+
+Project-agnostic: the package directory is auto-detected from the zip (the
+single top-level folder, or a root-level layout), so this script is drop-in for
+any plugin without editing constants.
 
 Checks:
   (a) every stored entry name uses forward-slash separators (no 0x5C bytes)
-  (b) the package-root files the installer needs are present
+  (b) the installer's required files are present at the package root
+      (plugin.json AND at least one of plugin.py / __init__.py)
   (c) no dev junk leaked in (.serena / .claude / __pycache__ / .git)
 
 Exit 0 if all pass; non-zero with a report otherwise.
 
-Usage: python scripts/validate_zip.py [path-to-zip]   (default: Stream-Mapparr.zip)
+Usage: python scripts/validate_zip.py [path-to-zip]   (default: first *.zip found
+       in CWD, else errors)
 """
+import glob
 import struct
 import sys
 import zipfile
 
-PKG = "Stream-Mapparr"
-REQUIRED = [f"{PKG}/plugin.py", f"{PKG}/plugin.json", f"{PKG}/__init__.py"]
-JUNK = (".serena", ".claude", "__pycache__", ".git")
-
+JUNK = (".serena", ".claude", "__pycache__", ".git/", "/.git")
 _CD_SIG = b"PK\x01\x02"  # central directory file header signature
 
 
@@ -40,16 +44,38 @@ def raw_entry_names(path):
     data = open(path, "rb").read()
     pos = data.find(_CD_SIG)
     while pos != -1:
-        # central dir header: name length is u16 at offset 28; name at offset 46
         name_len = struct.unpack_from("<H", data, pos + 28)[0]
         extra_len = struct.unpack_from("<H", data, pos + 30)[0]
         comment_len = struct.unpack_from("<H", data, pos + 32)[0]
-        name = data[pos + 46 : pos + 46 + name_len]
-        yield name
+        yield data[pos + 46 : pos + 46 + name_len]
         pos = data.find(_CD_SIG, pos + 46 + name_len + extra_len + comment_len)
 
 
+def detect_package_root(names):
+    """Return (prefix, note). prefix is '' for a root layout or 'Pkg/' for a
+    single-top-level-folder layout. note is None on success, else a diagnostic."""
+    files = [n for n in names if not n.endswith("/")]
+    root_files = [n for n in files if "/" not in n]
+    top_dirs = sorted({n.split("/", 1)[0] for n in files if "/" in n})
+
+    if any(f in ("plugin.py", "plugin.json", "__init__.py") for f in root_files):
+        return "", None  # root layout (files at zip root)
+    if len(top_dirs) == 1 and not root_files:
+        return top_dirs[0] + "/", None
+    if len(top_dirs) == 1:
+        # one package dir plus stray root files — tolerate, package dir wins
+        return top_dirs[0] + "/", None
+    return None, f"cannot identify a single package root (top-level dirs={top_dirs}, root_files={root_files[:5]})"
+
+
 def main(path):
+    if not path:
+        zips = sorted(glob.glob("*.zip"))
+        if len(zips) != 1:
+            print(f"FAIL: specify a zip path (found {len(zips)} *.zip in CWD)")
+            return 1
+        path = zips[0]
+
     try:
         names = zipfile.ZipFile(path).namelist()
     except (OSError, zipfile.BadZipFile) as exc:
@@ -66,10 +92,16 @@ def main(path):
             f"or git archive, NOT Compress-Archive): {backslash[:5]}"
         )
 
-    # (b) required package-root files (namelist normalizes separators, fine here)
-    missing = [r for r in REQUIRED if r not in names]
-    if missing:
-        errors.append(f"missing required package files: {missing}")
+    # (b) required installer files at the auto-detected package root
+    prefix, note = detect_package_root(names)
+    if note:
+        errors.append(note)
+    else:
+        nameset = set(names)
+        if prefix + "plugin.json" not in nameset:
+            errors.append(f"missing {prefix}plugin.json")
+        if not ({prefix + "plugin.py", prefix + "__init__.py"} & nameset):
+            errors.append(f"missing both {prefix}plugin.py and {prefix}__init__.py")
 
     # (c) dev junk
     junk = [n for n in names if any(j in n for j in JUNK)]
@@ -82,9 +114,10 @@ def main(path):
             print(f"  - {e}")
         return 1
 
-    print(f"OK: {path} ({len(names)} entries, forward-slash paths, package root intact)")
+    root = prefix or "(root)"
+    print(f"OK: {path} ({len(names)} entries, forward-slash paths, package root '{root}' intact)")
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "Stream-Mapparr.zip"))
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else None))


### PR DESCRIPTION
Refactors validate_zip.py to auto-detect the package directory so it is drop-in for any sibling plugin (no hardcoded 'Stream-Mapparr'). Part of porting the bug-087 packaging guard across the plugin family. Sweep of all PiratesIRC plugin release zips found only stream-mapparr was ever broken; this makes the guard reusable for the others as prevention.