### PR TITLE
Add EPG-aware placeholder matching

### DIFF
--- a/Stream-Mapparr/plugin.py
+++ b/Stream-Mapparr/plugin.py
@@ -310,6 +310,20 @@ class PluginConfig:
     DEFAULT_PRIORITIZE_QUALITY = False          # When true, sort quality before M3U source priority
     DEFAULT_ALLOW_SAME_NAME_STREAMS = False     # Opt-in: keep distinct same-named streams from one source (bug-140)
 
+    # === EPG-AWARE PLACEHOLDER MATCHING ===
+    DEFAULT_EPG_PLACEHOLDER_MATCHING_ENABLED = False   # Opt-in: resolve placeholder names via current EPG programme
+    DEFAULT_EPG_PLACEHOLDER_NAME_PATTERNS = (
+        r"^PPV EVENT \d+$" "\n"
+        r"^LIVE EVENT \d+$" "\n"
+        r"^PPV \d+ \|?$" "\n"
+        r"^HBO \d+$"
+    )
+    DEFAULT_EPG_TITLE_CLEANUP_RULES = (
+        '[["^Next Event:\\\\s*", ""], '
+        '["\\\\s+at \\\\d{1,2}:\\\\d{2}\\\\s*[AP]M on \\\\w+ \\\\d{1,2}$", ""]]'
+    )
+    DEFAULT_EPG_SKIP_TITLES = "Signing Off,No Event Today,No Game Today"  # Idle/no-signal placeholder titles to ignore
+
     # === RATE LIMITING DELAYS (seconds) - used for pacing ORM operations ===
     DEFAULT_RATE_LIMITING = "none"              # Options: none, low, medium, high
     RATE_LIMIT_NONE = 0.0                       # No rate limiting
@@ -739,6 +753,63 @@ class Plugin:
                              "sorting, zone routing, country restriction and duplicate "
                              "detection still read the original name. Use the Test Regex "
                              "Rules action to preview the effect.",
+            },
+            {
+                "id": "_section_epg_matching",
+                "label": "EPG-Aware Placeholder Matching",
+                "type": "info",
+                "description": (
+                    "Some providers give PPV/event slots generic placeholder names "
+                    "(e.g. 'PPV EVENT 04') on both the channel and the raw stream, while "
+                    "the real event title only ever appears in EPG programme data. When "
+                    "enabled, a channel or stream whose name matches one of the patterns "
+                    "below is matched using its CURRENTLY AIRING EPG programme title "
+                    "instead of its literal name — so a channel you've named for a "
+                    "specific event (e.g. 'AEW Redemption') can match a generically-named "
+                    "incoming stream once that event is the one airing on it. "
+                    "Matching only: Channel.name and Stream.name are never modified."
+                ),
+            },
+            {
+                "id": "epg_placeholder_matching_enabled",
+                "label": "📡 Enable EPG-Based Placeholder Matching",
+                "type": "boolean",
+                "default": PluginConfig.DEFAULT_EPG_PLACEHOLDER_MATCHING_ENABLED,
+                "help_text": "Master toggle for EPG-aware placeholder matching. Off by default.",
+            },
+            {
+                "id": "epg_placeholder_name_patterns",
+                "label": "🏷️ Placeholder Name Patterns (one regex per line)",
+                "type": "string",
+                "default": PluginConfig.DEFAULT_EPG_PLACEHOLDER_NAME_PATTERNS,
+                "placeholder": "^PPV EVENT \\d+$",
+                "help_text": "A channel or stream name is only ever treated as a generic "
+                             "placeholder (eligible for EPG substitution) if it matches one "
+                             "of these regexes. Anything else (e.g. 'Dodgers', 'AEW "
+                             "Redemption') is matched exactly as it is today — no behavior "
+                             "change. One Python regex per line.",
+            },
+            {
+                "id": "epg_title_cleanup_rules",
+                "label": "🧽 EPG Title Cleanup Rules (JSON)",
+                "type": "string",
+                "default": PluginConfig.DEFAULT_EPG_TITLE_CLEANUP_RULES,
+                "placeholder": '[["^Next Event:\\\\s*", ""], ["\\\\s+at \\\\d{1,2}:\\\\d{2}\\\\s*[AP]M on \\\\w+ \\\\d{1,2}$", ""]]',
+                "help_text": "Same [find, replace] JSON format as Stream Name Regex Rules "
+                             "above, applied to the raw EPG programme title before it's used "
+                             "for matching (e.g. strips a 'Next Event: X at 6:00AM on Jul 26' "
+                             "wrapper down to just 'X').",
+            },
+            {
+                "id": "epg_skip_titles",
+                "label": "⏭️ Skip Titles (comma-separated)",
+                "type": "string",
+                "default": PluginConfig.DEFAULT_EPG_SKIP_TITLES,
+                "placeholder": "Signing Off",
+                "help_text": "If the cleaned current EPG title matches one of these "
+                             "(case-insensitive), the channel/stream is left on its literal "
+                             "placeholder name for this pass — there's no useful event "
+                             "signal available (e.g. the slot is idle).",
             },
             {
                 "id": "prioritize_quality",
@@ -1856,14 +1927,16 @@ class Plugin:
                 enabled.add(db_info['id'])
         return enabled if enabled else None
 
-    def _resolve_stream_regex_rules(self, settings):
-        """Parse + gate the stream_name_regex_rules setting (spec §3/§4).
+    def _resolve_stream_regex_rules(self, settings, setting_key="stream_name_regex_rules"):
+        """Parse + gate a [find, replace] regex-rules JSON setting (spec §3/§4).
+        `setting_key` defaults to stream_name_regex_rules but any setting using the
+        same JSON shape can reuse this parser (e.g. epg_title_cleanup_rules).
         Returns (rules, report): rules = [(compiled, replacement)] that passed
         every gate; report = per-rule {index, pattern, status, detail}.
         Degrade-don't-fail: never raises. Empty/absent setting -> ([], [])."""
         cfg = PluginConfig
         settings = settings if isinstance(settings, dict) else {}
-        raw = (settings.get("stream_name_regex_rules") or "").strip()
+        raw = (settings.get(setting_key) or "").strip()
         if not raw:
             return [], []
         try:
@@ -1871,7 +1944,7 @@ class Plugin:
             if not isinstance(data, list):
                 raise ValueError("top level must be a JSON array")
         except Exception as e:
-            LOGGER.warning(f"[Stream-Mapparr] stream_name_regex_rules: invalid JSON - "
+            LOGGER.warning(f"[Stream-Mapparr] {setting_key}: invalid JSON - "
                            f"feature disabled: {e}")
             return [], [{"index": 0, "pattern": raw[:80], "status": "invalid_json_shape",
                          "detail": str(e)}]
@@ -1924,6 +1997,156 @@ class Plugin:
         if rejected:
             return [f"❌ Regex rules: {len(rules)} ok, {len(rejected)} rejected (see logs)"]
         return [f"✅ Regex rules: {len(rules)} ok"]
+
+    # ── EPG-aware placeholder matching ─────────────────────────────────────
+    # Some providers give PPV/event slots generic placeholder names (channel AND
+    # raw stream) while the real event title only ever lives in EPG programme
+    # data. These helpers resolve a placeholder name to its currently-airing EPG
+    # title for MATCHING PURPOSES ONLY — Channel.name/Stream.name are never
+    # written to.
+
+    def _resolve_epg_placeholder_patterns(self, settings):
+        """Parse + compile the epg_placeholder_name_patterns setting (one regex
+        per line or comma-separated, blank entries ignored). Degrade-don't-fail:
+        an invalid pattern is logged and skipped rather than raising. Empty or
+        absent setting -> []."""
+        settings = settings if isinstance(settings, dict) else {}
+        raw = (settings.get("epg_placeholder_name_patterns") or "").strip()
+        if not raw:
+            return []
+        compiled = []
+        for line in raw.replace(",", "\n").splitlines():
+            pattern = line.strip()
+            if not pattern:
+                continue
+            try:
+                compiled.append(re.compile(pattern, re.IGNORECASE))
+            except re.error as e:
+                LOGGER.warning(f"[Stream-Mapparr] epg_placeholder_name_patterns: "
+                               f"skipping invalid pattern {pattern!r}: {e}")
+        return compiled
+
+    def _is_epg_placeholder_name(self, name, patterns):
+        """True if `name` matches one of the configured placeholder patterns —
+        i.e. it's a generic provider slot name eligible for EPG substitution."""
+        if not name or not patterns:
+            return False
+        return any(p.search(name) for p in patterns)
+
+    def _resolve_current_epg_title_for_epg_data_id(self, epg_data_id, cleanup_rules, skip_titles):
+        """Shared primitive: look up the programme currently airing on the given
+        EPGData id (start_time <= now < end_time), clean its title, and return it
+        — or None if there's no current programme, the cleaned title is empty, or
+        it matches a configured skip title (idle/no-signal placeholder)."""
+        if not epg_data_id:
+            return None
+        try:
+            from apps.epg.models import ProgramData
+            now = timezone.now()
+            title = (ProgramData.objects
+                     .filter(epg_id=epg_data_id, start_time__lte=now, end_time__gt=now)
+                     .order_by('start_time')
+                     .values_list('title', flat=True)
+                     .first())
+        except Exception as e:
+            LOGGER.debug(f"[Stream-Mapparr] EPG lookup failed for epg_data_id={epg_data_id}: {e}")
+            return None
+        if not title:
+            return None
+        cleaned = title
+        for compiled, replacement in cleanup_rules:
+            try:
+                cleaned = compiled.sub(replacement, cleaned)
+            except Exception:
+                continue
+        cleaned = cleaned.strip()
+        if not cleaned:
+            return None
+        if skip_titles and cleaned.lower() in skip_titles:
+            return None
+        return cleaned
+
+    def _resolve_current_epg_title_for_channel(self, channel, cleanup_rules, skip_titles):
+        """Channel-side case: a Channel has a direct epg_data FK."""
+        return self._resolve_current_epg_title_for_epg_data_id(
+            channel.get('epg_data_id'), cleanup_rules, skip_titles)
+
+    def _resolve_current_epg_title_for_stream(self, stream, cleanup_rules, skip_titles, epg_data_id_cache):
+        """Stream-side case — the concrete scenario this feature exists for: a
+        Stream has no direct epg_data FK, only a tvg_id string that has to be
+        joined against EPGData.tvg_id. `epg_data_id_cache` is a dict the caller
+        keeps for the duration of one matching pass so repeated/blank tvg_ids
+        don't re-query."""
+        tvg_id = (stream.get('tvg_id') or '').strip()
+        if not tvg_id:
+            return None
+        if tvg_id in epg_data_id_cache:
+            epg_data_id = epg_data_id_cache[tvg_id]
+        else:
+            try:
+                from apps.epg.models import EPGData
+                epg_data_id = EPGData.objects.filter(tvg_id=tvg_id).values_list('id', flat=True).first()
+            except Exception as e:
+                LOGGER.debug(f"[Stream-Mapparr] EPGData lookup failed for tvg_id={tvg_id}: {e}")
+                epg_data_id = None
+            epg_data_id_cache[tvg_id] = epg_data_id
+        if not epg_data_id:
+            return None
+        return self._resolve_current_epg_title_for_epg_data_id(epg_data_id, cleanup_rules, skip_titles)
+
+    def _resolve_epg_matching_settings(self, settings):
+        """Resolve the epg_* settings once per pass into the dict consumed by both
+        _apply_epg_resolution_to_streams (stream side) and _match_streams_to_channel
+        (channel side, via its epg_settings= param) — same pre-resolve-once-before-
+        the-loop convention as ignore_tags/current_threshold/etc."""
+        settings = settings if isinstance(settings, dict) else {}
+        enabled = self._get_bool_setting(settings, 'epg_placeholder_matching_enabled',
+                                          PluginConfig.DEFAULT_EPG_PLACEHOLDER_MATCHING_ENABLED)
+        patterns = self._resolve_epg_placeholder_patterns(settings) if enabled else []
+        cleanup_rules, _ = self._resolve_stream_regex_rules(settings, setting_key="epg_title_cleanup_rules")
+        skip_titles = {t.strip().lower() for t in
+                       settings.get("epg_skip_titles", PluginConfig.DEFAULT_EPG_SKIP_TITLES).split(",")
+                       if t.strip()}
+        return {
+            "enabled": enabled and bool(patterns),
+            "patterns": patterns,
+            "cleanup_rules": cleanup_rules,
+            "skip_titles": skip_titles,
+        }
+
+    def _apply_epg_resolution_to_streams(self, streams, settings, logger=None):
+        """Stamp stream['match_name'] with the currently-airing EPG programme
+        title for any stream whose raw name matches a configured placeholder
+        pattern. Runs AFTER _apply_regex_rules_to_streams in the same pass and
+        overrides its result for placeholder streams only — regex cleanup and EPG
+        resolution are complementary: EPG is the stronger signal when a
+        placeholder slot actually has one. Never mutates stream['name']; every
+        other consumer (ordering, quality sort, CSV/display) keeps reading the
+        literal name. Degrade-don't-fail throughout — a lookup failure just
+        leaves that stream on whatever match_name it already had."""
+        epg_settings = self._resolve_epg_matching_settings(settings)
+        if not epg_settings["enabled"]:
+            return {"resolved": 0, "checked": 0}
+        patterns = epg_settings["patterns"]
+        cleanup_rules = epg_settings["cleanup_rules"]
+        skip_titles = epg_settings["skip_titles"]
+        epg_data_id_cache = {}
+        resolved = 0
+        checked = 0
+        for s in streams:
+            raw_name = s.get("name") or ""
+            if not self._is_epg_placeholder_name(raw_name, patterns):
+                continue
+            checked += 1
+            title = self._resolve_current_epg_title_for_stream(
+                s, cleanup_rules, skip_titles, epg_data_id_cache)
+            if title:
+                s["match_name"] = title
+                resolved += 1
+        if logger and checked:
+            logger.info(f"[Stream-Mapparr] EPG placeholder matching: {resolved}/{checked} "
+                        f"placeholder stream(s) resolved to a current EPG title")
+        return {"resolved": resolved, "checked": checked}
 
     def _initialize_fuzzy_matcher(self, match_threshold=85):
         """Initialize the fuzzy matcher with configured threshold."""
@@ -2034,7 +2257,10 @@ class Plugin:
 
     def _get_all_channels(self, logger):
         """Fetch all channels via Django ORM."""
-        fields = ['id', 'name', 'channel_number', 'channel_group_id', 'channel_group__name']
+        # 'epg_data_id' is fetched for EPG-aware placeholder matching (resolves a
+        # placeholder-named channel's currently airing programme title).
+        fields = ['id', 'name', 'channel_number', 'channel_group_id', 'channel_group__name',
+                  'epg_data_id']
         # Include attached_channel_id if the model has it (used by visibility management)
         try:
             Channel._meta.get_field('attached_channel')
@@ -2046,8 +2272,10 @@ class Plugin:
     def _get_all_streams(self, logger):
         """Fetch all streams via Django ORM, returning dicts compatible with existing processing logic."""
         # 'url' is fetched for the allow_same_name_streams dedup key (bug-140).
+        # 'tvg_id' is fetched for EPG-aware placeholder matching (a Stream has no direct
+        # epg_data FK like Channel does, so its EPG data is looked up via tvg_id).
         return list(Stream.objects.all().values(
-            'id', 'name', 'm3u_account', 'url', 'channel_group', 'channel_group__name'
+            'id', 'name', 'm3u_account', 'url', 'channel_group', 'channel_group__name', 'tvg_id'
         ))
 
     def _get_all_m3u_accounts(self, logger):
@@ -3165,8 +3393,15 @@ class Plugin:
                                   ignore_quality=True, ignore_regional=True, ignore_geographic=True,
                                   ignore_misc=True, channels_data=None, filter_dead=False,
                                   restrict_matching_to_country=False,
-                                  allow_same_name_streams=False):
-        """Find matching streams for a channel using fuzzy matching when available."""
+                                  allow_same_name_streams=False, epg_settings=None):
+        """Find matching streams for a channel using fuzzy matching when available.
+
+        `epg_settings`, when provided as {'enabled', 'patterns', 'cleanup_rules',
+        'skip_titles'} (see _resolve_epg_matching_settings), lets a placeholder-named
+        channel (e.g. still literally 'PPV EVENT 04') be matched using its currently
+        airing EPG programme title instead — the stream side of the same feature is
+        handled upstream via stream['match_name'] (_apply_epg_resolution_to_streams),
+        so `all_streams`/_mname() already reflect it by the time this runs."""
         if ignore_tags is None:
             ignore_tags = []
         if channels_data is None:
@@ -3179,6 +3414,14 @@ class Plugin:
             working_streams = all_streams
 
         channel_name = channel['name']
+        if epg_settings and epg_settings.get('enabled') and self._is_epg_placeholder_name(
+                channel_name, epg_settings.get('patterns')):
+            epg_title = self._resolve_current_epg_title_for_channel(
+                channel, epg_settings.get('cleanup_rules', []), epg_settings.get('skip_titles', set()))
+            if epg_title:
+                logger.debug(f"[Stream-Mapparr] Channel '{channel_name}' is a placeholder name — "
+                             f"matching against current EPG title '{epg_title}' instead")
+                channel_name = epg_title
         if restrict_matching_to_country:
             channel_country_code = self._extract_channel_country_code(channel)
             if channel_country_code:
@@ -4923,6 +5166,8 @@ class Plugin:
             regex_rules, regex_report = self._resolve_stream_regex_rules(settings)
             regex_rejected = sum(1 for r in regex_report if r["status"] != "ok")
             _apply_regex_rules_to_streams(streams, regex_rules, logger)
+            epg_settings = self._resolve_epg_matching_settings(settings)
+            self._apply_epg_resolution_to_streams(streams, settings, logger)
             visible_channel_limit = processed_data.get('visible_channel_limit', 1)
             ignore_tags = processed_data.get('ignore_tags', [])
 
@@ -4997,7 +5242,7 @@ class Plugin:
                 matched_streams, cleaned_channel_name, cleaned_stream_names, match_reason, database_used = self._match_streams_to_channel(
                     sorted_channels[0], streams, logger, ignore_tags, ignore_quality, ignore_regional,
                     ignore_geographic, ignore_misc, channels_data, filter_dead, restrict_matching_to_country,
-                    allow_same_name_streams
+                    allow_same_name_streams, epg_settings=epg_settings
                 )
 
                 # Track group stats
@@ -5209,6 +5454,8 @@ class Plugin:
             regex_rules, regex_report = self._resolve_stream_regex_rules(settings)
             regex_rejected = sum(1 for r in regex_report if r["status"] != "ok")
             _apply_regex_rules_to_streams(streams, regex_rules, logger)
+            epg_settings = self._resolve_epg_matching_settings(settings)
+            self._apply_epg_resolution_to_streams(streams, settings, logger)
             ignore_tags = processed_data.get('ignore_tags', [])
             visible_channel_limit = processed_data.get('visible_channel_limit', PluginConfig.DEFAULT_VISIBLE_CHANNEL_LIMIT)
             overwrite_streams = settings.get('overwrite_streams', PluginConfig.DEFAULT_OVERWRITE_STREAMS)
@@ -5287,7 +5534,7 @@ class Plugin:
                 matched_streams, _, _, _, _ = self._match_streams_to_channel(
                     sorted_channels[0], streams, logger, ignore_tags, ignore_quality, ignore_regional,
                     ignore_geographic, ignore_misc, channels_data, filter_dead, restrict_matching_to_country,
-                    allow_same_name_streams
+                    allow_same_name_streams, epg_settings=epg_settings
                 )
 
                 # Track group stats
@@ -5581,6 +5828,7 @@ class Plugin:
             regex_rules, regex_report = self._resolve_stream_regex_rules(settings)
             regex_rejected = sum(1 for r in regex_report if r["status"] != "ok")
             _apply_regex_rules_to_streams(all_streams, regex_rules, logger)
+            self._apply_epg_resolution_to_streams(all_streams, settings, logger)
 
             if not all_streams:
                 error_msg = "No streams found in Dispatcharr"


### PR DESCRIPTION
## Summary

Some providers (IPTVboss-style PPV/event feeds among them) deliberately keep channel and stream names as generic placeholders (`PPV EVENT 04`, `LIVE EVENT 12`) and push the actual event information through EPG data on a rolling basis instead — the placeholder identity stays fixed, but its EPG programme updates to whatever's currently airing. That's a reasonable design choice on the provider side and gives genuinely good, timely EPG data — but it means Stream-Mapparr's name-based fuzzy matching never sees the real event name, so a channel a user names for a specific event (e.g. `AEW Redemption`) can't match the stream actually carrying it.

This teaches the matching engine to optionally resolve a placeholder-named channel or stream to its currently-airing EPG title before fuzzy comparison, instead of comparing the literal placeholder text — using the same EPG data the provider already supplies, just at the point where it's actually useful for matching.

- New settings: `epg_placeholder_matching_enabled` (off by default), `epg_placeholder_name_patterns`, `epg_title_cleanup_rules`, `epg_skip_titles`.
- `_get_all_channels`/`_get_all_streams` now fetch `epg_data_id`/`tvg_id`.
- New helpers resolve the currently-airing `ProgramData` title for a placeholder-named channel (via its `epg_data` FK) or stream (via `tvg_id` → `EPGData`), clean it per configurable rules, and skip idle/no-signal titles (`Signing Off`, `No Event Today`, `No Game Today` by default).
- Wired into `_match_streams_to_channel` (channel-side substitution) and via `_apply_epg_resolution_to_streams` stamping `stream['match_name']` (stream-side, the primary case) — same `match_name` choke point the existing regex-rules feature already uses, so every downstream matching/quality/callsign code path picks it up automatically.
- **Matching-only**: `Channel.name`/`Stream.name` are never modified.

## Test plan

- [x] Full existing test suite passes unmodified (648 tests).
- [x] Verified live against a real Dispatcharr instance: the fuzzy matcher scores a real `AEW Redemption` EPG-resolved stream title at 77 against a channel named `AEW Redemption` (threshold 70).
- [x] Deployed and ran Match & Assign for real — three separate placeholder streams (`LIVE EVENT 01`, `PPV EVENT 09`, `PPV EVENT 08`) were correctly assigned to that channel.
- [x] Confirmed non-placeholder channels match exactly as before (no regression) and that generic idle titles shared across many unrelated channels don't cause over-matching (initially found and fixed a real bug here — `No Event Today`/`No Game Today` needed adding to the default skip list after they caused 130-stream over-matching in testing).

Happy to adjust naming/scope/defaults per maintainer preference — opening this for consideration since it seemed likely to help other users with PPV/event-style provider feeds, not just my own setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)