### PR TITLE
Add EPG-aware placeholder matching

### DIFF
--- a/Stream-Mapparr/CHANGELOG.md
+++ b/Stream-Mapparr/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Stream-Mapparr CHANGELOG
 
+## v1.26.2142011 (August 2, 2026)
+
+Response to maintainer review on PR #42 — measured, reproducible findings on
+all four points; every repro case re-verified against the fixed code.
+
+### Fixed
+- **`epg_placeholder_name_patterns` bypassed the regex safety gate.** It compiled
+  user-supplied patterns with a bare `re.compile()`, skipping the same
+  `_pattern_is_unsafe()` check `stream_name_regex_rules` already goes through —
+  measured live: `^(a+)+$` rejected by the existing gate, accepted by this one,
+  then 3+ seconds to match a single 27-character stream name, inside a
+  uWSGI/gevent worker that never yields mid-match. `_resolve_epg_placeholder_patterns`
+  now runs the exact same gate (reject + log unsafe/over-length patterns, cap
+  pattern count), and the placeholder-matching loop in
+  `_apply_epg_resolution_to_streams` gained the same runtime containment
+  `_apply_regex_rules_to_streams` already has (input length cap, cumulative
+  wall-clock budget, cooperative yields). `_is_epg_placeholder_name` also
+  switched `.search()` to `.fullmatch()` — a no-op against the shipped
+  (already-anchored) defaults, but correct for a future unanchored
+  user-written pattern deciding whole-name eligibility.
+- **The "is this event today" check read Django's active timezone (UTC), not
+  Dispatcharr's configured one.** `_epg_next_event_date_is_today` used
+  `timezone.localtime(timezone.now())`, which only ever reflects
+  `settings.TIME_ZONE` — a plugin never sees the per-request timezone
+  activation Django applies in the normal request path. Measured live: Django's
+  active tz was UTC while `CoreSettings.get_system_time_zone()` was
+  America/Phoenix, a 7-hour gap where the two calendar days disagree every
+  single day — exactly the evening hours live events actually air. New
+  `_epg_local_now()` helper resolves through `_dispatcharr_timezone()` (the
+  same helper the scheduler already uses), matching its `pytz.timezone(...)` +
+  `datetime.now(tz)` idiom.
+- **The date comparison was string equality, not a real date compare.**
+  `"August 5"` and `"Aug 05"` were silently rejected even when today was
+  "Aug 5" — nothing logged, so there was no way to notice. Now parses the
+  captured date (trying abbreviated and full month names, both accepting
+  1- or 2-digit days) and compares `(month, day)` tuples. An unrecognized
+  format is now logged and treated permissively, instead of silently and
+  irreversibly discarding the match.
+- **N+1 EPG queries per channel group.** `_collect_epg_watch_streams` rebuilt
+  its lookup cache on every call and `_resolve_current_epg_title_for_epg_data_id`
+  never cached its `ProgramData` query at all — measured live at roughly 8600
+  synchronous ORM queries in a single pass on a 1440-channel instance, inside a
+  non-yielding greenlet. New per-run `epg_title_cache`, built once alongside
+  the existing `channel_info_cache` and threaded through the same call chain,
+  memoizes the resolved title per EPG record id for the whole pass.
+
+### Changed
+- `epg_skip_titles` and `epg_watch_source_streams` now guard against an
+  explicit `None` value the same way `epg_channel_schedule_cleanup_rules`
+  already did — previously only that one setting had the `is None` check,
+  so the other two could raise `AttributeError` on a null value.
+- `_collect_epg_watch_streams` now requires a channel name to clean down to
+  at least 2 tokens before attempting the containment check — a single-token
+  name ("Max", "Live", "News") would otherwise force-include a watched stream
+  on a large fraction of its daily programming, the same shape of over-match
+  this plugin already hit once (a shared idle EPG title over-matching 130
+  streams) arriving from a different angle.
+
 ## v1.26.2121807 (July 31, 2026)
 
 ### Fixed

--- a/Stream-Mapparr/CHANGELOG.md
+++ b/Stream-Mapparr/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Stream-Mapparr CHANGELOG
 
+## v1.26.2110101 (July 29, 2026)
+
+### Fixed
+- **EPG-aware placeholder matching silently stopped matching schedule-suffixed channel
+  names.** Without provider-assigned channel numbers, a natural convention is to name event
+  channels with an inline schedule (e.g. `WWE Monday Night Raw | Monday @ 5`). That trailing
+  annotation was never stripped before matching, so it diluted the fuzzy-match score against
+  a resolved EPG title (`WWE MONDAY NIGHT RAW`) below threshold — confirmed live at 60%/40%
+  against a 70% threshold for two real channels — and its stray digit separately tripped the
+  channel-has-numbers-so-stream-must-too guard meant for cases like `BBC1` vs `CBBC`. New
+  setting `epg_channel_schedule_cleanup_rules` (same `[find, replace]` JSON shape as the
+  existing EPG/regex cleanup rules) strips this suffix from the channel name — matching
+  only, `Channel.name` is never modified — before it's compared against a resolved EPG
+  title. Only applies when EPG-based placeholder matching is enabled, so unrelated matching
+  is unaffected.
+
 ## v1.26.2072208 (July 26, 2026)
 
 ### Added

--- a/Stream-Mapparr/CHANGELOG.md
+++ b/Stream-Mapparr/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Stream-Mapparr CHANGELOG
 
+## v1.26.2121751 (July 31, 2026)
+
+### Added
+- **EPG Event Watch: match a real, permanently-named stream by its current programme,
+  not just placeholder-named ones.** Some events never get their own dedicated
+  placeholder feed at all — a WWE PPV's only guide presence turned out to be
+  time-boxed pre-show coverage on ESPN/ESPN2/ESPN News, verified live: a "WWE
+  SummerSlam" channel had zero candidates because none of the placeholder-name
+  patterns apply to a channel that's genuinely, permanently named "ESPN". New
+  setting `epg_watch_source_streams` (comma-separated exact stream names, empty =
+  disabled) opts specific real channels into being considered as an EXTRA
+  alternate for any channel whose full cleaned name is contained in that stream's
+  current EPG title — deliberately a token-containment check, not the usual
+  whole-string similarity ratio, since a real programme title is typically the
+  event name plus promotional wrapping ("WWE SummerSlam Special") that dilutes a
+  string ratio below any reasonable threshold even for a correct hit (measured
+  60–63% live against a 70% threshold). A watched stream's own identity is never
+  touched — it keeps matching its own literally-named channel exactly as before;
+  this only adds it as a candidate elsewhere. First unit test coverage for any
+  part of the EPG-aware matching feature (7 tests), including a regression guard
+  for an unrelated-show false positive found while validating this live.
+
 ## v1.26.2110111 (July 30, 2026)
 
 ### Changed

--- a/Stream-Mapparr/CHANGELOG.md
+++ b/Stream-Mapparr/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Stream-Mapparr CHANGELOG
 
+## v1.26.2110111 (July 30, 2026)
+
+### Changed
+- **Default EPG placeholder name patterns now cover `MAX #` and `Triller TV | Event #`.**
+  A live census of one deployment's stream names found six numbered-placeholder families
+  sharing the same `Next Event: X at TIME on DATE` / `No Event Today` EPG format as the
+  already-covered `HBO #`/`PPV EVENT #`/`PPV # |`/`LIVE EVENT #` patterns — but two of them,
+  `MAX #` (128 streams, the single largest category) and `Triller TV | Event #` (14 streams),
+  had no matching pattern and so were silently never eligible for EPG resolution. Both use
+  the same `ProgramData` shape confirmed against live data before being added. Existing
+  saved `epg_placeholder_name_patterns` settings are not retroactively changed — add the two
+  new lines yourself if you already customized this setting.
+
 ## v1.26.2110101 (July 29, 2026)
 
 ### Fixed

--- a/Stream-Mapparr/CHANGELOG.md
+++ b/Stream-Mapparr/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Stream-Mapparr CHANGELOG
 
+## v1.26.2121807 (July 31, 2026)
+
+### Fixed
+- **A "Next Event: X at TIME on DATE" placeholder could be reported as today's event
+  while actually days or weeks out.** The guide's "what's coming up" block stays the
+  CURRENTLY ACTIVE `ProgramData` row until the real event starts, however far off
+  that is — confirmed live: 84 such rows active at once, most dated a week-plus in
+  the future (e.g. `Next Event: AEW Dynamite: Grand Slam Mexico at 05:00PM on Aug 5`
+  live and "current" on Jul 31). Stripping the `at TIME on DATE` clause and matching
+  on the bare title (the existing cleanup-rules behavior) would have surfaced that
+  future event as though it aired today. `_resolve_current_epg_title_for_epg_data_id`
+  now checks the embedded date against today's date (via `timezone.localtime`, the
+  configured/active timezone) before resolving a "Next Event" placeholder at all —
+  a title with no such date clause (e.g. a live, unwrapped title once the provider
+  flips it) is unaffected. Applies to every EPG-aware matching path (placeholder
+  names and the new EPG Event Watch) since they share this one primitive.
+
 ## v1.26.2121751 (July 31, 2026)
 
 ### Added

--- a/Stream-Mapparr/plugin.json
+++ b/Stream-Mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.2072208",
+  "version": "1.26.2110101",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/Stream-Mapparr/plugin.json
+++ b/Stream-Mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.2110101",
+  "version": "1.26.2110111",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/Stream-Mapparr/plugin.json
+++ b/Stream-Mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.2110111",
+  "version": "1.26.2121751",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/Stream-Mapparr/plugin.json
+++ b/Stream-Mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.2121807",
+  "version": "1.26.2142011",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/Stream-Mapparr/plugin.json
+++ b/Stream-Mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.2121751",
+  "version": "1.26.2121807",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/Stream-Mapparr/plugin.py
+++ b/Stream-Mapparr/plugin.py
@@ -276,7 +276,7 @@ class PluginConfig:
     """
 
     # === PLUGIN METADATA ===
-    PLUGIN_VERSION = "1.26.2110101"
+    PLUGIN_VERSION = "1.26.2110111"
     FUZZY_MATCHER_MIN_VERSION = "25.358.0200"  # Requires custom ignore tags Unicode fix
 
     # Match sensitivity presets (maps select value to threshold number)
@@ -317,7 +317,9 @@ class PluginConfig:
         r"^PPV EVENT \d+$" "\n"
         r"^LIVE EVENT \d+$" "\n"
         r"^PPV \d+ \|?$" "\n"
-        r"^HBO \d+$"
+        r"^HBO \d+$" "\n"
+        r"^MAX \d+$" "\n"
+        r"^Triller TV \| Event \d+$"
     )
     DEFAULT_EPG_TITLE_CLEANUP_RULES = (
         '[["^Next Event:\\\\s*", ""], '

--- a/Stream-Mapparr/plugin.py
+++ b/Stream-Mapparr/plugin.py
@@ -276,7 +276,7 @@ class PluginConfig:
     """
 
     # === PLUGIN METADATA ===
-    PLUGIN_VERSION = "1.26.2121807"
+    PLUGIN_VERSION = "1.26.2142011"
     FUZZY_MATCHER_MIN_VERSION = "25.358.0200"  # Requires custom ignore tags Unicode fix
 
     # Match sensitivity presets (maps select value to threshold number)
@@ -2082,31 +2082,58 @@ class Plugin:
 
     def _resolve_epg_placeholder_patterns(self, settings):
         """Parse + compile the epg_placeholder_name_patterns setting (one regex
-        per line or comma-separated, blank entries ignored). Degrade-don't-fail:
-        an invalid pattern is logged and skipped rather than raising. Empty or
-        absent setting -> []."""
+        per line or comma-separated, blank entries ignored). Same safety gate as
+        _resolve_stream_regex_rules — a bare re.compile() here would let a
+        catastrophic-backtracking pattern through a second door, and this one
+        runs .fullmatch() against every stream name in the pass, in a
+        non-yielding uWSGI/gevent worker (review finding: ^(a+)+$ measured at
+        3s against a single 27-char name). Degrade-don't-fail: an invalid,
+        unsafe, or over-length pattern is logged and skipped rather than
+        raising or being silently accepted. Empty or absent setting -> []."""
+        cfg = PluginConfig
         settings = settings if isinstance(settings, dict) else {}
         raw = (settings.get("epg_placeholder_name_patterns") or "").strip()
         if not raw:
             return []
         compiled = []
-        for line in raw.replace(",", "\n").splitlines():
-            pattern = line.strip()
+        for pattern in raw.replace(",", "\n").splitlines():
+            pattern = pattern.strip()
             if not pattern:
                 continue
+            if len(compiled) + 1 > cfg.REGEX_RULES_MAX:
+                LOGGER.warning(f"[Stream-Mapparr] epg_placeholder_name_patterns: "
+                               f"over the {cfg.REGEX_RULES_MAX}-pattern cap, skipping {pattern!r}")
+                continue
+            if len(pattern) > cfg.REGEX_PATTERN_MAX_LEN:
+                LOGGER.warning(f"[Stream-Mapparr] epg_placeholder_name_patterns: "
+                               f"pattern over {cfg.REGEX_PATTERN_MAX_LEN} chars, skipping {pattern!r}")
+                continue
             try:
-                compiled.append(re.compile(pattern, re.IGNORECASE))
+                candidate = re.compile(pattern, re.IGNORECASE)
             except re.error as e:
                 LOGGER.warning(f"[Stream-Mapparr] epg_placeholder_name_patterns: "
                                f"skipping invalid pattern {pattern!r}: {e}")
+                continue
+            if _pattern_is_unsafe(pattern):
+                LOGGER.warning(f"[Stream-Mapparr] epg_placeholder_name_patterns: "
+                               f"skipping unsafe pattern {pattern!r} — nested unbounded "
+                               f"quantifier or alternation inside +/* can backtrack "
+                               f"exponentially; rewrite without nesting +/* "
+                               f"(Python 3.11+: atomic groups (?>...) / possessive a*+)")
+                continue
+            compiled.append(candidate)
         return compiled
 
     def _is_epg_placeholder_name(self, name, patterns):
-        """True if `name` matches one of the configured placeholder patterns —
-        i.e. it's a generic provider slot name eligible for EPG substitution."""
+        """True if `name` fully matches one of the configured placeholder
+        patterns — i.e. it's a generic provider slot name eligible for EPG
+        substitution. fullmatch (not search): this setting decides eligibility
+        for the WHOLE name, so an unanchored user pattern shouldn't match a
+        mere substring anywhere in it. All shipped defaults are already
+        ^...$-anchored, so this is a no-op against them."""
         if not name or not patterns:
             return False
-        return any(p.search(name) for p in patterns)
+        return any(p.fullmatch(name) for p in patterns)
 
     # Matches the trailing "at HH:MMAM/PM on Mon D" clause a provider appends to a
     # still-WAITING placeholder title ("Next Event: X at 05:00PM on Aug 5") -- see
@@ -2114,6 +2141,27 @@ class Plugin:
     # prefix: the date clause itself is the signal, regardless of wrapper wording.
     _EPG_NEXT_EVENT_DATE_RE = re.compile(
         r'\bat\s+\d{1,2}:\d{2}\s*[AP]M\s+on\s+([A-Za-z]{3,9}\s+\d{1,2})\s*$', re.IGNORECASE)
+
+    # Recognized month-name formats for the captured "Mon D" / "Month D" clause.
+    # Tried in order; both accept 1- or 2-digit days (CPython strptime is
+    # lenient on %d input, unlike strftime's always-zero-padded output), so
+    # "Aug 5", "Aug 05", "August 5" and "August 05" all parse to the same date.
+    _EPG_NEXT_EVENT_DATE_FORMATS = ("%b %d %Y", "%B %d %Y")
+
+    def _epg_local_now(self):
+        """Current time in Dispatcharr's user-configured timezone (General
+        Settings -> Time Zone), NOT Django's active timezone. Django's active
+        timezone is settings.TIME_ZONE (UTC in Dispatcharr) — a plugin never
+        sees the per-request timezone activation Django applies in the normal
+        request path, so timezone.localtime() silently returns UTC regardless
+        of what the user configured. Same pytz.timezone(...) + datetime.now(tz)
+        idiom the scheduler already uses (_start_background_scheduler_locked).
+        Falls back to UTC on any error, matching _dispatcharr_timezone's own
+        fail-safe."""
+        try:
+            return datetime.now(pytz.timezone(self._dispatcharr_timezone()))
+        except Exception:
+            return datetime.now(pytz.utc)
 
     def _epg_next_event_date_is_today(self, title):
         """A "Next Event: X at TIME on DATE" placeholder can stay the CURRENTLY
@@ -2126,28 +2174,52 @@ class Plugin:
         (nothing to validate -- a live, unwrapped title like "WWE MONDAY NIGHT RAW
         ᴺᵉʷ" is exactly what a real live event looks like once the
         provider flips it from the waiting placeholder) or when the embedded date
-        is today's date; False only when a date IS embedded and it is not today.
+        is today's date (compared as an actual (month, day) pair, not a string —
+        "August 5" and "Aug 05" both mean the same day as "Aug 5"); False only
+        when a date IS embedded, parses, and is not today. An embedded date that
+        doesn't parse against either recognized format is logged (so a provider
+        using an unrecognized month convention shows up instead of silently
+        losing every match) and treated permissively, same as no date at all.
         """
         m = self._EPG_NEXT_EVENT_DATE_RE.search(title or '')
         if not m:
             return True
-        try:
-            today = timezone.localtime(timezone.now())
-        except Exception:
-            return True  # degrade-don't-fail: can't verify, don't block on it
-        today_str = f"{today.strftime('%b')} {today.day}"
-        return m.group(1).strip().lower() == today_str.lower()
+        today = self._epg_local_now()
+        captured = m.group(1).strip()
+        for fmt in self._EPG_NEXT_EVENT_DATE_FORMATS:
+            try:
+                parsed = datetime.strptime(f"{captured} {today.year}", fmt)
+            except ValueError:
+                continue
+            return (parsed.month, parsed.day) == (today.month, today.day)
+        LOGGER.debug(f"[Stream-Mapparr] Next Event date clause {captured!r} did not "
+                     f"match a recognized month format — treating as today")
+        return True
 
-    def _resolve_current_epg_title_for_epg_data_id(self, epg_data_id, cleanup_rules, skip_titles):
+    def _resolve_current_epg_title_for_epg_data_id(self, epg_data_id, cleanup_rules, skip_titles,
+                                                    epg_title_cache=None):
         """Shared primitive: look up the programme currently airing on the given
         EPGData id (start_time <= now < end_time), clean its title, and return it
         — or None if there's no current programme, the cleaned title is empty, it
         matches a configured skip title (idle/no-signal placeholder), or it's a
         "Next Event: X at TIME on DATE" placeholder whose date isn't today (bug:
         such placeholders can stay "current" for days -- see
-        _epg_next_event_date_is_today)."""
+        _epg_next_event_date_is_today).
+
+        `epg_title_cache`, when provided, is a dict the caller keeps for the
+        duration of one matching pass, keyed by epg_data_id — a cache HIT
+        (including a cached None) returns immediately, before this function
+        does anything else, since a cached entry already reflects every gate
+        below. Without this, the same currently-airing ProgramData row gets
+        re-queried once per channel group that considers it, however many
+        times that is in a pass (review finding: ~8600 synchronous ORM
+        queries in one run on a 1440-channel instance, inside a
+        non-yielding greenlet). Default None preserves the exact old
+        per-call behavior for any caller that doesn't pass one."""
         if not epg_data_id:
             return None
+        if epg_title_cache is not None and epg_data_id in epg_title_cache:
+            return epg_title_cache[epg_data_id]
         try:
             from apps.epg.models import ProgramData
             now = timezone.now()
@@ -2158,35 +2230,39 @@ class Plugin:
                      .first())
         except Exception as e:
             LOGGER.debug(f"[Stream-Mapparr] EPG lookup failed for epg_data_id={epg_data_id}: {e}")
+            if epg_title_cache is not None:
+                epg_title_cache[epg_data_id] = None
             return None
-        if not title:
-            return None
-        if not self._epg_next_event_date_is_today(title):
-            return None
-        cleaned = title
-        for compiled, replacement in cleanup_rules:
-            try:
-                cleaned = compiled.sub(replacement, cleaned)
-            except Exception:
-                continue
-        cleaned = cleaned.strip()
-        if not cleaned:
-            return None
-        if skip_titles and cleaned.lower() in skip_titles:
-            return None
-        return cleaned
+        result = None
+        if title and self._epg_next_event_date_is_today(title):
+            cleaned = title
+            for compiled, replacement in cleanup_rules:
+                try:
+                    cleaned = compiled.sub(replacement, cleaned)
+                except Exception:
+                    continue
+            cleaned = cleaned.strip()
+            if cleaned and not (skip_titles and cleaned.lower() in skip_titles):
+                result = cleaned
+        if epg_title_cache is not None:
+            epg_title_cache[epg_data_id] = result
+        return result
 
-    def _resolve_current_epg_title_for_channel(self, channel, cleanup_rules, skip_titles):
+    def _resolve_current_epg_title_for_channel(self, channel, cleanup_rules, skip_titles,
+                                                epg_title_cache=None):
         """Channel-side case: a Channel has a direct epg_data FK."""
         return self._resolve_current_epg_title_for_epg_data_id(
-            channel.get('epg_data_id'), cleanup_rules, skip_titles)
+            channel.get('epg_data_id'), cleanup_rules, skip_titles, epg_title_cache)
 
-    def _resolve_current_epg_title_for_stream(self, stream, cleanup_rules, skip_titles, epg_data_id_cache):
+    def _resolve_current_epg_title_for_stream(self, stream, cleanup_rules, skip_titles, epg_data_id_cache,
+                                               epg_title_cache=None):
         """Stream-side case — the concrete scenario this feature exists for: a
         Stream has no direct epg_data FK, only a tvg_id string that has to be
         joined against EPGData.tvg_id. `epg_data_id_cache` is a dict the caller
         keeps for the duration of one matching pass so repeated/blank tvg_ids
-        don't re-query."""
+        don't re-query. `epg_title_cache` — see
+        _resolve_current_epg_title_for_epg_data_id — separately memoizes the
+        currently-airing title per epg_data_id, once that's resolved."""
         tvg_id = (stream.get('tvg_id') or '').strip()
         if not tvg_id:
             return None
@@ -2202,7 +2278,8 @@ class Plugin:
             epg_data_id_cache[tvg_id] = epg_data_id
         if not epg_data_id:
             return None
-        return self._resolve_current_epg_title_for_epg_data_id(epg_data_id, cleanup_rules, skip_titles)
+        return self._resolve_current_epg_title_for_epg_data_id(
+            epg_data_id, cleanup_rules, skip_titles, epg_title_cache)
 
     def _resolve_epg_matching_settings(self, settings):
         """Resolve the epg_* settings once per pass into the dict consumed by both
@@ -2214,19 +2291,26 @@ class Plugin:
                                           PluginConfig.DEFAULT_EPG_PLACEHOLDER_MATCHING_ENABLED)
         patterns = self._resolve_epg_placeholder_patterns(settings) if enabled else []
         cleanup_rules, _ = self._resolve_stream_regex_rules(settings, setting_key="epg_title_cleanup_rules")
-        skip_titles = {t.strip().lower() for t in
-                       settings.get("epg_skip_titles", PluginConfig.DEFAULT_EPG_SKIP_TITLES).split(",")
-                       if t.strip()}
+        # is-None guards on these three (not just a .get(key, DEFAULT) default): the
+        # DEFAULT only applies when the key is ABSENT. If Dispatcharr ever persists
+        # the key with an explicit None value, .get() returns None (not the
+        # default) and .split(",") on it raises -- review note (previously only
+        # epg_channel_schedule_cleanup_rules had this guard; now all three match).
+        raw_skip_titles = settings.get("epg_skip_titles")
+        if raw_skip_titles is None:
+            raw_skip_titles = PluginConfig.DEFAULT_EPG_SKIP_TITLES
+        skip_titles = {t.strip().lower() for t in raw_skip_titles.split(",") if t.strip()}
         raw_channel_cleanup = settings.get("epg_channel_schedule_cleanup_rules")
         if raw_channel_cleanup is None:
             raw_channel_cleanup = PluginConfig.DEFAULT_EPG_CHANNEL_SCHEDULE_CLEANUP_RULES
         channel_schedule_cleanup_rules, _ = self._resolve_stream_regex_rules(
             {"epg_channel_schedule_cleanup_rules": raw_channel_cleanup},
             setting_key="epg_channel_schedule_cleanup_rules")
+        raw_watch_source_streams = settings.get("epg_watch_source_streams")
+        if raw_watch_source_streams is None:
+            raw_watch_source_streams = PluginConfig.DEFAULT_EPG_WATCH_SOURCE_STREAMS
         watch_source_stream_names = {
-            n.strip().lower() for n in
-            settings.get("epg_watch_source_streams", PluginConfig.DEFAULT_EPG_WATCH_SOURCE_STREAMS).split(",")
-            if n.strip()
+            n.strip().lower() for n in raw_watch_source_streams.split(",") if n.strip()
         }
         return {
             "enabled": enabled and bool(patterns),
@@ -2237,7 +2321,7 @@ class Plugin:
             "watch_source_stream_names": watch_source_stream_names,
         }
 
-    def _apply_epg_resolution_to_streams(self, streams, settings, logger=None):
+    def _apply_epg_resolution_to_streams(self, streams, settings, logger=None, epg_title_cache=None):
         """Stamp stream['match_name'] with the currently-airing EPG programme
         title for any stream whose raw name matches a configured placeholder
         pattern. Runs AFTER _apply_regex_rules_to_streams in the same pass and
@@ -2246,7 +2330,16 @@ class Plugin:
         placeholder slot actually has one. Never mutates stream['name']; every
         other consumer (ordering, quality sort, CSV/display) keeps reading the
         literal name. Degrade-don't-fail throughout — a lookup failure just
-        leaves that stream on whatever match_name it already had."""
+        leaves that stream on whatever match_name it already had.
+
+        Same runtime containment as _apply_regex_rules_to_streams (review
+        finding: this loop calls _is_epg_placeholder_name — a regex fullmatch —
+        against every stream name, with none of that containment, inside a
+        uWSGI/gevent worker that never yields mid-match): an input length cap,
+        a cumulative wall-clock budget that disables further matching for the
+        rest of the pass, and cooperative time.sleep(0) yields. No output-
+        growth cap here since this loop only matches, it never substitutes."""
+        cfg = PluginConfig
         epg_settings = self._resolve_epg_matching_settings(settings)
         if not epg_settings["enabled"]:
             return {"resolved": 0, "checked": 0}
@@ -2256,19 +2349,36 @@ class Plugin:
         epg_data_id_cache = {}
         resolved = 0
         checked = 0
-        for s in streams:
+        skipped_long = 0
+        budget_tripped = False
+        deadline = time.monotonic() + cfg.REGEX_PASS_BUDGET_S
+        for i, s in enumerate(streams):
+            if i and i % cfg.REGEX_YIELD_EVERY == 0:
+                time.sleep(0)  # gevent: yield the worker between batches
+            if budget_tripped:
+                continue
+            if time.monotonic() >= deadline:
+                budget_tripped = True
+                continue
             raw_name = s.get("name") or ""
+            if len(raw_name) > cfg.REGEX_NAME_MAX_LEN:
+                skipped_long += 1
+                continue
             if not self._is_epg_placeholder_name(raw_name, patterns):
                 continue
             checked += 1
             title = self._resolve_current_epg_title_for_stream(
-                s, cleanup_rules, skip_titles, epg_data_id_cache)
+                s, cleanup_rules, skip_titles, epg_data_id_cache, epg_title_cache)
             if title:
                 s["match_name"] = title
                 resolved += 1
-        if logger and checked:
+        if logger and (checked or skipped_long or budget_tripped):
             logger.info(f"[Stream-Mapparr] EPG placeholder matching: {resolved}/{checked} "
-                        f"placeholder stream(s) resolved to a current EPG title")
+                        f"placeholder stream(s) resolved to a current EPG title"
+                        + (f", {skipped_long} name(s) over {cfg.REGEX_NAME_MAX_LEN} chars skipped"
+                           if skipped_long else "")
+                        + (", TIME BUDGET EXCEEDED - matching disabled for the rest of this run"
+                           if budget_tripped else ""))
         return {"resolved": resolved, "checked": checked}
 
     def _initialize_fuzzy_matcher(self, match_threshold=85):
@@ -2353,9 +2463,17 @@ class Plugin:
             return []
         return [s for s in working_streams if _mname(s) in hit_names]
 
+    # A channel name that cleans down to fewer tokens than this is too generic
+    # to safely force-include a watched stream on ("Max", "Live", "News" would
+    # each swallow a large fraction of any watched stream's daily programming)
+    # -- the same shape of over-match this file already hit once (bug: 130
+    # streams over-matched on a shared idle EPG title) arriving from a
+    # different angle. Cheap insurance; review note.
+    _EPG_WATCH_MIN_CHANNEL_TOKENS = 2
+
     def _collect_epg_watch_streams(self, channel_name, working_streams, epg_settings,
                                     ignore_tags, ignore_quality, ignore_regional,
-                                    ignore_geographic, ignore_misc):
+                                    ignore_geographic, ignore_misc, epg_title_cache=None):
         """Force-include streams from `epg_settings['watch_source_stream_names']` whose
         CURRENT EPG programme title contains the full target channel name — the
         "ESPN airs a WWE SummerSlam pre-show" case, where the real event never gets
@@ -2382,6 +2500,19 @@ class Plugin:
         variants that dropped the "WWE" token, using the exact same cleaning path
         (_clean_channel_name) as every other comparison in this file so tag/quality
         handling stays consistent.
+
+        Below `_EPG_WATCH_MIN_CHANNEL_TOKENS` cleaned tokens, a channel name is
+        too generic to safely gate on containment alone (review note: "Max",
+        "Live", "News" would each force-include on a large fraction of a
+        watched stream's daily programming) — the same shape of over-match
+        this file already hit once from a different angle (bug-140-adjacent:
+        a shared idle EPG title over-matched 130 streams).
+
+        `epg_title_cache`, when provided by the caller, memoizes the resolved
+        current title per EPG record id across the whole run (see
+        _resolve_current_epg_title_for_epg_data_id) — this function is called
+        once per channel group, so without it every watched stream's current
+        title is re-queried once per group.
         """
         watch_names = epg_settings.get('watch_source_stream_names') if epg_settings else None
         if not watch_names:
@@ -2389,7 +2520,7 @@ class Plugin:
         channel_tokens = set(self._clean_channel_name(
             channel_name, ignore_tags, ignore_quality, ignore_regional,
             ignore_geographic, ignore_misc).lower().split())
-        if not channel_tokens:
+        if len(channel_tokens) < self._EPG_WATCH_MIN_CHANNEL_TOKENS:
             return []
         cleanup_rules = epg_settings.get('cleanup_rules', [])
         skip_titles = epg_settings.get('skip_titles', set())
@@ -2399,7 +2530,7 @@ class Plugin:
             if (stream.get('name') or '').strip().lower() not in watch_names:
                 continue
             title = self._resolve_current_epg_title_for_stream(
-                stream, cleanup_rules, skip_titles, epg_data_id_cache)
+                stream, cleanup_rules, skip_titles, epg_data_id_cache, epg_title_cache)
             if not title:
                 continue
             title_tokens = set(self._clean_channel_name(
@@ -3738,7 +3869,7 @@ class Plugin:
                                   restrict_matching_to_country=False,
                                   allow_same_name_streams=False, country_stats=None,
                                   stream_country_memo=None, channel_info_cache=None,
-                                  epg_settings=None):
+                                  epg_settings=None, epg_title_cache=None):
         """Find matching streams for a channel using fuzzy matching when available.
 
         `stream_country_memo` / `channel_info_cache` (bug-158 review I3): optional
@@ -3754,6 +3885,12 @@ class Plugin:
         airing EPG programme title instead — the stream side of the same feature is
         handled upstream via stream['match_name'] (_apply_epg_resolution_to_streams),
         so `all_streams`/_mname() already reflect it by the time this runs.
+
+        `epg_title_cache`, same convention as `channel_info_cache` — an optional
+        dict a caller builds once per run and threads through every group's call,
+        memoizing the currently-airing title per EPG record id so it isn't
+        re-queried once per channel group (see
+        _resolve_current_epg_title_for_epg_data_id).
         """
         if ignore_tags is None:
             ignore_tags = []
@@ -3784,7 +3921,8 @@ class Plugin:
         if epg_settings and epg_settings.get('enabled') and self._is_epg_placeholder_name(
                 channel_name, epg_settings.get('patterns')):
             epg_title = self._resolve_current_epg_title_for_channel(
-                channel, epg_settings.get('cleanup_rules', []), epg_settings.get('skip_titles', set()))
+                channel, epg_settings.get('cleanup_rules', []), epg_settings.get('skip_titles', set()),
+                epg_title_cache)
             if epg_title:
                 logger.debug(f"[Stream-Mapparr] Channel '{channel_name}' is a placeholder name — "
                              f"matching against current EPG title '{epg_title}' instead")
@@ -3912,7 +4050,8 @@ class Plugin:
             epg_watch_streams = (
                 self._collect_epg_watch_streams(
                     channel_name, working_streams, epg_settings, ignore_tags,
-                    ignore_quality, ignore_regional, ignore_geographic, ignore_misc)
+                    ignore_quality, ignore_regional, ignore_geographic, ignore_misc,
+                    epg_title_cache)
                 if epg_settings and epg_settings.get('enabled') else []
             )
             alias_ids = {id(s) for s in alias_streams} | {id(s) for s in epg_watch_streams}
@@ -5750,7 +5889,13 @@ class Plugin:
             regex_rejected = sum(1 for r in regex_report if r["status"] != "ok")
             _apply_regex_rules_to_streams(streams, regex_rules, logger)
             epg_settings = self._resolve_epg_matching_settings(settings)
-            self._apply_epg_resolution_to_streams(streams, settings, logger)
+            # Per-run cache: memoizes the currently-airing title per EPG record id
+            # across the whole pass (review finding: without this, the placeholder-
+            # matching stream pass AND every channel group's EPG event watch check
+            # each re-query ProgramData independently). Same convention as
+            # channel_info_cache below.
+            epg_title_cache = {}
+            self._apply_epg_resolution_to_streams(streams, settings, logger, epg_title_cache)
             visible_channel_limit = processed_data.get('visible_channel_limit', 1)
             ignore_tags = processed_data.get('ignore_tags', [])
 
@@ -5832,7 +5977,7 @@ class Plugin:
                     ignore_geographic, ignore_misc, channels_data, filter_dead, restrict_matching_to_country,
                     allow_same_name_streams, country_stats=country_stats,
                     stream_country_memo=stream_country_memo, channel_info_cache=channel_info_cache,
-                    epg_settings=epg_settings
+                    epg_settings=epg_settings, epg_title_cache=epg_title_cache
                 )
 
                 # Track group stats
@@ -6090,7 +6235,9 @@ class Plugin:
             regex_rejected = sum(1 for r in regex_report if r["status"] != "ok")
             _apply_regex_rules_to_streams(streams, regex_rules, logger)
             epg_settings = self._resolve_epg_matching_settings(settings)
-            self._apply_epg_resolution_to_streams(streams, settings, logger)
+            # Per-run cache: see preview_changes_action for why this is needed.
+            epg_title_cache = {}
+            self._apply_epg_resolution_to_streams(streams, settings, logger, epg_title_cache)
             ignore_tags = processed_data.get('ignore_tags', [])
             visible_channel_limit = processed_data.get('visible_channel_limit', PluginConfig.DEFAULT_VISIBLE_CHANNEL_LIMIT)
             overwrite_streams = settings.get('overwrite_streams', PluginConfig.DEFAULT_OVERWRITE_STREAMS)
@@ -6176,7 +6323,7 @@ class Plugin:
                     ignore_geographic, ignore_misc, channels_data, filter_dead, restrict_matching_to_country,
                     allow_same_name_streams, country_stats=country_stats,
                     stream_country_memo=stream_country_memo, channel_info_cache=channel_info_cache,
-                    epg_settings=epg_settings
+                    epg_settings=epg_settings, epg_title_cache=epg_title_cache
                 )
 
                 # Track group stats

--- a/Stream-Mapparr/plugin.py
+++ b/Stream-Mapparr/plugin.py
@@ -311,6 +311,20 @@ class PluginConfig:
     DEFAULT_PRIORITIZE_QUALITY = False          # When true, sort quality before M3U source priority
     DEFAULT_ALLOW_SAME_NAME_STREAMS = False     # Opt-in: keep distinct same-named streams from one source (bug-140)
 
+    # === EPG-AWARE PLACEHOLDER MATCHING ===
+    DEFAULT_EPG_PLACEHOLDER_MATCHING_ENABLED = False   # Opt-in: resolve placeholder names via current EPG programme
+    DEFAULT_EPG_PLACEHOLDER_NAME_PATTERNS = (
+        r"^PPV EVENT \d+$" "\n"
+        r"^LIVE EVENT \d+$" "\n"
+        r"^PPV \d+ \|?$" "\n"
+        r"^HBO \d+$"
+    )
+    DEFAULT_EPG_TITLE_CLEANUP_RULES = (
+        '[["^Next Event:\\\\s*", ""], '
+        '["\\\\s+at \\\\d{1,2}:\\\\d{2}\\\\s*[AP]M on \\\\w+ \\\\d{1,2}$", ""]]'
+    )
+    DEFAULT_EPG_SKIP_TITLES = "Signing Off,No Event Today,No Game Today"  # Idle/no-signal placeholder titles to ignore
+
     # === RATE LIMITING DELAYS (seconds) - used for pacing ORM operations ===
     DEFAULT_RATE_LIMITING = "none"              # Options: none, low, medium, high
     RATE_LIMIT_NONE = 0.0                       # No rate limiting
@@ -752,6 +766,63 @@ class Plugin:
                              "sorting, zone routing, country restriction and duplicate "
                              "detection still read the original name. Use the Test Regex "
                              "Rules action to preview the effect.",
+            },
+            {
+                "id": "_section_epg_matching",
+                "label": "EPG-Aware Placeholder Matching",
+                "type": "info",
+                "description": (
+                    "Some providers give PPV/event slots generic placeholder names "
+                    "(e.g. 'PPV EVENT 04') on both the channel and the raw stream, while "
+                    "the real event title only ever appears in EPG programme data. When "
+                    "enabled, a channel or stream whose name matches one of the patterns "
+                    "below is matched using its CURRENTLY AIRING EPG programme title "
+                    "instead of its literal name — so a channel you've named for a "
+                    "specific event (e.g. 'AEW Redemption') can match a generically-named "
+                    "incoming stream once that event is the one airing on it. "
+                    "Matching only: Channel.name and Stream.name are never modified."
+                ),
+            },
+            {
+                "id": "epg_placeholder_matching_enabled",
+                "label": "📡 Enable EPG-Based Placeholder Matching",
+                "type": "boolean",
+                "default": PluginConfig.DEFAULT_EPG_PLACEHOLDER_MATCHING_ENABLED,
+                "help_text": "Master toggle for EPG-aware placeholder matching. Off by default.",
+            },
+            {
+                "id": "epg_placeholder_name_patterns",
+                "label": "🏷️ Placeholder Name Patterns (one regex per line)",
+                "type": "string",
+                "default": PluginConfig.DEFAULT_EPG_PLACEHOLDER_NAME_PATTERNS,
+                "placeholder": "^PPV EVENT \\d+$",
+                "help_text": "A channel or stream name is only ever treated as a generic "
+                             "placeholder (eligible for EPG substitution) if it matches one "
+                             "of these regexes. Anything else (e.g. 'Dodgers', 'AEW "
+                             "Redemption') is matched exactly as it is today — no behavior "
+                             "change. One Python regex per line.",
+            },
+            {
+                "id": "epg_title_cleanup_rules",
+                "label": "🧽 EPG Title Cleanup Rules (JSON)",
+                "type": "string",
+                "default": PluginConfig.DEFAULT_EPG_TITLE_CLEANUP_RULES,
+                "placeholder": '[["^Next Event:\\\\s*", ""], ["\\\\s+at \\\\d{1,2}:\\\\d{2}\\\\s*[AP]M on \\\\w+ \\\\d{1,2}$", ""]]',
+                "help_text": "Same [find, replace] JSON format as Stream Name Regex Rules "
+                             "above, applied to the raw EPG programme title before it's used "
+                             "for matching (e.g. strips a 'Next Event: X at 6:00AM on Jul 26' "
+                             "wrapper down to just 'X').",
+            },
+            {
+                "id": "epg_skip_titles",
+                "label": "⏭️ Skip Titles (comma-separated)",
+                "type": "string",
+                "default": PluginConfig.DEFAULT_EPG_SKIP_TITLES,
+                "placeholder": "Signing Off",
+                "help_text": "If the cleaned current EPG title matches one of these "
+                             "(case-insensitive), the channel/stream is left on its literal "
+                             "placeholder name for this pass — there's no useful event "
+                             "signal available (e.g. the slot is idle).",
             },
             {
                 "id": "prioritize_quality",
@@ -1887,14 +1958,16 @@ class Plugin:
                 enabled.add(db_info['id'])
         return enabled if enabled else None
 
-    def _resolve_stream_regex_rules(self, settings):
-        """Parse + gate the stream_name_regex_rules setting (spec §3/§4).
+    def _resolve_stream_regex_rules(self, settings, setting_key="stream_name_regex_rules"):
+        """Parse + gate a [find, replace] regex-rules JSON setting (spec §3/§4).
+        `setting_key` defaults to stream_name_regex_rules but any setting using the
+        same JSON shape can reuse this parser (e.g. epg_title_cleanup_rules).
         Returns (rules, report): rules = [(compiled, replacement)] that passed
         every gate; report = per-rule {index, pattern, status, detail}.
         Degrade-don't-fail: never raises. Empty/absent setting -> ([], [])."""
         cfg = PluginConfig
         settings = settings if isinstance(settings, dict) else {}
-        raw = (settings.get("stream_name_regex_rules") or "").strip()
+        raw = (settings.get(setting_key) or "").strip()
         if not raw:
             return [], []
         try:
@@ -1902,7 +1975,7 @@ class Plugin:
             if not isinstance(data, list):
                 raise ValueError("top level must be a JSON array")
         except Exception as e:
-            LOGGER.warning(f"[Stream-Mapparr] stream_name_regex_rules: invalid JSON - "
+            LOGGER.warning(f"[Stream-Mapparr] {setting_key}: invalid JSON - "
                            f"feature disabled: {e}")
             return [], [{"index": 0, "pattern": raw[:80], "status": "invalid_json_shape",
                          "detail": str(e)}]
@@ -1955,6 +2028,156 @@ class Plugin:
         if rejected:
             return [f"❌ Regex rules: {len(rules)} ok, {len(rejected)} rejected (see logs)"]
         return [f"✅ Regex rules: {len(rules)} ok"]
+
+    # ── EPG-aware placeholder matching ─────────────────────────────────────
+    # Some providers give PPV/event slots generic placeholder names (channel AND
+    # raw stream) while the real event title only ever lives in EPG programme
+    # data. These helpers resolve a placeholder name to its currently-airing EPG
+    # title for MATCHING PURPOSES ONLY — Channel.name/Stream.name are never
+    # written to.
+
+    def _resolve_epg_placeholder_patterns(self, settings):
+        """Parse + compile the epg_placeholder_name_patterns setting (one regex
+        per line or comma-separated, blank entries ignored). Degrade-don't-fail:
+        an invalid pattern is logged and skipped rather than raising. Empty or
+        absent setting -> []."""
+        settings = settings if isinstance(settings, dict) else {}
+        raw = (settings.get("epg_placeholder_name_patterns") or "").strip()
+        if not raw:
+            return []
+        compiled = []
+        for line in raw.replace(",", "\n").splitlines():
+            pattern = line.strip()
+            if not pattern:
+                continue
+            try:
+                compiled.append(re.compile(pattern, re.IGNORECASE))
+            except re.error as e:
+                LOGGER.warning(f"[Stream-Mapparr] epg_placeholder_name_patterns: "
+                               f"skipping invalid pattern {pattern!r}: {e}")
+        return compiled
+
+    def _is_epg_placeholder_name(self, name, patterns):
+        """True if `name` matches one of the configured placeholder patterns —
+        i.e. it's a generic provider slot name eligible for EPG substitution."""
+        if not name or not patterns:
+            return False
+        return any(p.search(name) for p in patterns)
+
+    def _resolve_current_epg_title_for_epg_data_id(self, epg_data_id, cleanup_rules, skip_titles):
+        """Shared primitive: look up the programme currently airing on the given
+        EPGData id (start_time <= now < end_time), clean its title, and return it
+        — or None if there's no current programme, the cleaned title is empty, or
+        it matches a configured skip title (idle/no-signal placeholder)."""
+        if not epg_data_id:
+            return None
+        try:
+            from apps.epg.models import ProgramData
+            now = timezone.now()
+            title = (ProgramData.objects
+                     .filter(epg_id=epg_data_id, start_time__lte=now, end_time__gt=now)
+                     .order_by('start_time')
+                     .values_list('title', flat=True)
+                     .first())
+        except Exception as e:
+            LOGGER.debug(f"[Stream-Mapparr] EPG lookup failed for epg_data_id={epg_data_id}: {e}")
+            return None
+        if not title:
+            return None
+        cleaned = title
+        for compiled, replacement in cleanup_rules:
+            try:
+                cleaned = compiled.sub(replacement, cleaned)
+            except Exception:
+                continue
+        cleaned = cleaned.strip()
+        if not cleaned:
+            return None
+        if skip_titles and cleaned.lower() in skip_titles:
+            return None
+        return cleaned
+
+    def _resolve_current_epg_title_for_channel(self, channel, cleanup_rules, skip_titles):
+        """Channel-side case: a Channel has a direct epg_data FK."""
+        return self._resolve_current_epg_title_for_epg_data_id(
+            channel.get('epg_data_id'), cleanup_rules, skip_titles)
+
+    def _resolve_current_epg_title_for_stream(self, stream, cleanup_rules, skip_titles, epg_data_id_cache):
+        """Stream-side case — the concrete scenario this feature exists for: a
+        Stream has no direct epg_data FK, only a tvg_id string that has to be
+        joined against EPGData.tvg_id. `epg_data_id_cache` is a dict the caller
+        keeps for the duration of one matching pass so repeated/blank tvg_ids
+        don't re-query."""
+        tvg_id = (stream.get('tvg_id') or '').strip()
+        if not tvg_id:
+            return None
+        if tvg_id in epg_data_id_cache:
+            epg_data_id = epg_data_id_cache[tvg_id]
+        else:
+            try:
+                from apps.epg.models import EPGData
+                epg_data_id = EPGData.objects.filter(tvg_id=tvg_id).values_list('id', flat=True).first()
+            except Exception as e:
+                LOGGER.debug(f"[Stream-Mapparr] EPGData lookup failed for tvg_id={tvg_id}: {e}")
+                epg_data_id = None
+            epg_data_id_cache[tvg_id] = epg_data_id
+        if not epg_data_id:
+            return None
+        return self._resolve_current_epg_title_for_epg_data_id(epg_data_id, cleanup_rules, skip_titles)
+
+    def _resolve_epg_matching_settings(self, settings):
+        """Resolve the epg_* settings once per pass into the dict consumed by both
+        _apply_epg_resolution_to_streams (stream side) and _match_streams_to_channel
+        (channel side, via its epg_settings= param) — same pre-resolve-once-before-
+        the-loop convention as ignore_tags/current_threshold/etc."""
+        settings = settings if isinstance(settings, dict) else {}
+        enabled = self._get_bool_setting(settings, 'epg_placeholder_matching_enabled',
+                                          PluginConfig.DEFAULT_EPG_PLACEHOLDER_MATCHING_ENABLED)
+        patterns = self._resolve_epg_placeholder_patterns(settings) if enabled else []
+        cleanup_rules, _ = self._resolve_stream_regex_rules(settings, setting_key="epg_title_cleanup_rules")
+        skip_titles = {t.strip().lower() for t in
+                       settings.get("epg_skip_titles", PluginConfig.DEFAULT_EPG_SKIP_TITLES).split(",")
+                       if t.strip()}
+        return {
+            "enabled": enabled and bool(patterns),
+            "patterns": patterns,
+            "cleanup_rules": cleanup_rules,
+            "skip_titles": skip_titles,
+        }
+
+    def _apply_epg_resolution_to_streams(self, streams, settings, logger=None):
+        """Stamp stream['match_name'] with the currently-airing EPG programme
+        title for any stream whose raw name matches a configured placeholder
+        pattern. Runs AFTER _apply_regex_rules_to_streams in the same pass and
+        overrides its result for placeholder streams only — regex cleanup and EPG
+        resolution are complementary: EPG is the stronger signal when a
+        placeholder slot actually has one. Never mutates stream['name']; every
+        other consumer (ordering, quality sort, CSV/display) keeps reading the
+        literal name. Degrade-don't-fail throughout — a lookup failure just
+        leaves that stream on whatever match_name it already had."""
+        epg_settings = self._resolve_epg_matching_settings(settings)
+        if not epg_settings["enabled"]:
+            return {"resolved": 0, "checked": 0}
+        patterns = epg_settings["patterns"]
+        cleanup_rules = epg_settings["cleanup_rules"]
+        skip_titles = epg_settings["skip_titles"]
+        epg_data_id_cache = {}
+        resolved = 0
+        checked = 0
+        for s in streams:
+            raw_name = s.get("name") or ""
+            if not self._is_epg_placeholder_name(raw_name, patterns):
+                continue
+            checked += 1
+            title = self._resolve_current_epg_title_for_stream(
+                s, cleanup_rules, skip_titles, epg_data_id_cache)
+            if title:
+                s["match_name"] = title
+                resolved += 1
+        if logger and checked:
+            logger.info(f"[Stream-Mapparr] EPG placeholder matching: {resolved}/{checked} "
+                        f"placeholder stream(s) resolved to a current EPG title")
+        return {"resolved": resolved, "checked": checked}
 
     def _initialize_fuzzy_matcher(self, match_threshold=85):
         """Initialize the fuzzy matcher with configured threshold."""
@@ -2065,7 +2288,10 @@ class Plugin:
 
     def _get_all_channels(self, logger):
         """Fetch all channels via Django ORM."""
-        fields = ['id', 'name', 'channel_number', 'channel_group_id', 'channel_group__name']
+        # 'epg_data_id' is fetched for EPG-aware placeholder matching (resolves a
+        # placeholder-named channel's currently airing programme title).
+        fields = ['id', 'name', 'channel_number', 'channel_group_id', 'channel_group__name',
+                  'epg_data_id']
         # Include attached_channel_id if the model has it (used by visibility management)
         try:
             Channel._meta.get_field('attached_channel')
@@ -2077,8 +2303,10 @@ class Plugin:
     def _get_all_streams(self, logger):
         """Fetch all streams via Django ORM, returning dicts compatible with existing processing logic."""
         # 'url' is fetched for the allow_same_name_streams dedup key (bug-140).
+        # 'tvg_id' is fetched for EPG-aware placeholder matching (a Stream has no direct
+        # epg_data FK like Channel does, so its EPG data is looked up via tvg_id).
         return list(Stream.objects.all().values(
-            'id', 'name', 'm3u_account', 'url', 'channel_group', 'channel_group__name'
+            'id', 'name', 'm3u_account', 'url', 'channel_group', 'channel_group__name', 'tvg_id'
         ))
 
     def _get_all_m3u_accounts(self, logger):
@@ -3361,7 +3589,8 @@ class Plugin:
                                   ignore_misc=True, channels_data=None, filter_dead=False,
                                   restrict_matching_to_country=False,
                                   allow_same_name_streams=False, country_stats=None,
-                                  stream_country_memo=None, channel_info_cache=None):
+                                  stream_country_memo=None, channel_info_cache=None,
+                                  epg_settings=None):
         """Find matching streams for a channel using fuzzy matching when available.
 
         `stream_country_memo` / `channel_info_cache` (bug-158 review I3): optional
@@ -3370,6 +3599,13 @@ class Plugin:
         and re-scanning channels_data from scratch. Both default to None, which
         reproduces the exact prior per-call computation -- see
         `_build_stream_country_memo` / `_get_channel_info_and_matches`.
+
+        `epg_settings`, when provided as {'enabled', 'patterns', 'cleanup_rules',
+        'skip_titles'} (see _resolve_epg_matching_settings), lets a placeholder-named
+        channel (e.g. still literally 'PPV EVENT 04') be matched using its currently
+        airing EPG programme title instead — the stream side of the same feature is
+        handled upstream via stream['match_name'] (_apply_epg_resolution_to_streams),
+        so `all_streams`/_mname() already reflect it by the time this runs.
         """
         if ignore_tags is None:
             ignore_tags = []
@@ -3383,6 +3619,14 @@ class Plugin:
             working_streams = all_streams
 
         channel_name = channel['name']
+        if epg_settings and epg_settings.get('enabled') and self._is_epg_placeholder_name(
+                channel_name, epg_settings.get('patterns')):
+            epg_title = self._resolve_current_epg_title_for_channel(
+                channel, epg_settings.get('cleanup_rules', []), epg_settings.get('skip_titles', set()))
+            if epg_title:
+                logger.debug(f"[Stream-Mapparr] Channel '{channel_name}' is a placeholder name — "
+                             f"matching against current EPG title '{epg_title}' instead")
+                channel_name = epg_title
         channel_info, channel_info_matches = self._get_channel_info_and_matches(
             channel, channels_data, logger, restrict_matching_to_country, channel_info_cache)
         database_used = channel_info.get('_country_code', 'N/A') if channel_info else 'N/A'
@@ -5331,6 +5575,8 @@ class Plugin:
             regex_rules, regex_report = self._resolve_stream_regex_rules(settings)
             regex_rejected = sum(1 for r in regex_report if r["status"] != "ok")
             _apply_regex_rules_to_streams(streams, regex_rules, logger)
+            epg_settings = self._resolve_epg_matching_settings(settings)
+            self._apply_epg_resolution_to_streams(streams, settings, logger)
             visible_channel_limit = processed_data.get('visible_channel_limit', 1)
             ignore_tags = processed_data.get('ignore_tags', [])
 
@@ -5411,7 +5657,8 @@ class Plugin:
                     sorted_channels[0], streams, logger, ignore_tags, ignore_quality, ignore_regional,
                     ignore_geographic, ignore_misc, channels_data, filter_dead, restrict_matching_to_country,
                     allow_same_name_streams, country_stats=country_stats,
-                    stream_country_memo=stream_country_memo, channel_info_cache=channel_info_cache
+                    stream_country_memo=stream_country_memo, channel_info_cache=channel_info_cache,
+                    epg_settings=epg_settings
                 )
 
                 # Track group stats
@@ -5668,6 +5915,8 @@ class Plugin:
             regex_rules, regex_report = self._resolve_stream_regex_rules(settings)
             regex_rejected = sum(1 for r in regex_report if r["status"] != "ok")
             _apply_regex_rules_to_streams(streams, regex_rules, logger)
+            epg_settings = self._resolve_epg_matching_settings(settings)
+            self._apply_epg_resolution_to_streams(streams, settings, logger)
             ignore_tags = processed_data.get('ignore_tags', [])
             visible_channel_limit = processed_data.get('visible_channel_limit', PluginConfig.DEFAULT_VISIBLE_CHANNEL_LIMIT)
             overwrite_streams = settings.get('overwrite_streams', PluginConfig.DEFAULT_OVERWRITE_STREAMS)
@@ -5752,7 +6001,8 @@ class Plugin:
                     sorted_channels[0], streams, logger, ignore_tags, ignore_quality, ignore_regional,
                     ignore_geographic, ignore_misc, channels_data, filter_dead, restrict_matching_to_country,
                     allow_same_name_streams, country_stats=country_stats,
-                    stream_country_memo=stream_country_memo, channel_info_cache=channel_info_cache
+                    stream_country_memo=stream_country_memo, channel_info_cache=channel_info_cache,
+                    epg_settings=epg_settings
                 )
 
                 # Track group stats
@@ -6074,6 +6324,7 @@ class Plugin:
             regex_rules, regex_report = self._resolve_stream_regex_rules(settings)
             regex_rejected = sum(1 for r in regex_report if r["status"] != "ok")
             _apply_regex_rules_to_streams(all_streams, regex_rules, logger)
+            self._apply_epg_resolution_to_streams(all_streams, settings, logger)
 
             if not all_streams:
                 error_msg = "No streams found in Dispatcharr"

--- a/Stream-Mapparr/plugin.py
+++ b/Stream-Mapparr/plugin.py
@@ -276,7 +276,7 @@ class PluginConfig:
     """
 
     # === PLUGIN METADATA ===
-    PLUGIN_VERSION = "1.26.2121751"
+    PLUGIN_VERSION = "1.26.2121807"
     FUZZY_MATCHER_MIN_VERSION = "25.358.0200"  # Requires custom ignore tags Unicode fix
 
     # Match sensitivity presets (maps select value to threshold number)
@@ -2108,11 +2108,44 @@ class Plugin:
             return False
         return any(p.search(name) for p in patterns)
 
+    # Matches the trailing "at HH:MMAM/PM on Mon D" clause a provider appends to a
+    # still-WAITING placeholder title ("Next Event: X at 05:00PM on Aug 5") -- see
+    # _epg_next_event_date_is_today. Deliberately does NOT require a "Next Event:"
+    # prefix: the date clause itself is the signal, regardless of wrapper wording.
+    _EPG_NEXT_EVENT_DATE_RE = re.compile(
+        r'\bat\s+\d{1,2}:\d{2}\s*[AP]M\s+on\s+([A-Za-z]{3,9}\s+\d{1,2})\s*$', re.IGNORECASE)
+
+    def _epg_next_event_date_is_today(self, title):
+        """A "Next Event: X at TIME on DATE" placeholder can stay the CURRENTLY
+        ACTIVE ProgramData row for days -- the guide's own "what's coming up"
+        block just keeps pointing at whatever is next, however far off (live data:
+        84 such rows active at once, most dated a week or more out). Stripping the
+        "at TIME on DATE" clause and returning the bare title (the existing
+        cleanup-rules behavior) would report that future event as though it were
+        happening today. True when `title` carries no such date clause at all
+        (nothing to validate -- a live, unwrapped title like "WWE MONDAY NIGHT RAW
+        ᴺᵉʷ" is exactly what a real live event looks like once the
+        provider flips it from the waiting placeholder) or when the embedded date
+        is today's date; False only when a date IS embedded and it is not today.
+        """
+        m = self._EPG_NEXT_EVENT_DATE_RE.search(title or '')
+        if not m:
+            return True
+        try:
+            today = timezone.localtime(timezone.now())
+        except Exception:
+            return True  # degrade-don't-fail: can't verify, don't block on it
+        today_str = f"{today.strftime('%b')} {today.day}"
+        return m.group(1).strip().lower() == today_str.lower()
+
     def _resolve_current_epg_title_for_epg_data_id(self, epg_data_id, cleanup_rules, skip_titles):
         """Shared primitive: look up the programme currently airing on the given
         EPGData id (start_time <= now < end_time), clean its title, and return it
-        — or None if there's no current programme, the cleaned title is empty, or
-        it matches a configured skip title (idle/no-signal placeholder)."""
+        — or None if there's no current programme, the cleaned title is empty, it
+        matches a configured skip title (idle/no-signal placeholder), or it's a
+        "Next Event: X at TIME on DATE" placeholder whose date isn't today (bug:
+        such placeholders can stay "current" for days -- see
+        _epg_next_event_date_is_today)."""
         if not epg_data_id:
             return None
         try:
@@ -2127,6 +2160,8 @@ class Plugin:
             LOGGER.debug(f"[Stream-Mapparr] EPG lookup failed for epg_data_id={epg_data_id}: {e}")
             return None
         if not title:
+            return None
+        if not self._epg_next_event_date_is_today(title):
             return None
         cleaned = title
         for compiled, replacement in cleanup_rules:

--- a/Stream-Mapparr/plugin.py
+++ b/Stream-Mapparr/plugin.py
@@ -276,7 +276,7 @@ class PluginConfig:
     """
 
     # === PLUGIN METADATA ===
-    PLUGIN_VERSION = "1.26.2072208"
+    PLUGIN_VERSION = "1.26.2110101"
     FUZZY_MATCHER_MIN_VERSION = "25.358.0200"  # Requires custom ignore tags Unicode fix
 
     # Match sensitivity presets (maps select value to threshold number)
@@ -324,6 +324,9 @@ class PluginConfig:
         '["\\\\s+at \\\\d{1,2}:\\\\d{2}\\\\s*[AP]M on \\\\w+ \\\\d{1,2}$", ""]]'
     )
     DEFAULT_EPG_SKIP_TITLES = "Signing Off,No Event Today,No Game Today"  # Idle/no-signal placeholder titles to ignore
+    DEFAULT_EPG_CHANNEL_SCHEDULE_CLEANUP_RULES = (
+        '[["(?i)\\\\s*\\\\|\\\\s*\\\\w+\\\\s*@\\\\s*\\\\d{1,2}(?::\\\\d{2})?\\\\s*[AP]?M?\\\\s*$", ""]]'
+    )
 
     # === RATE LIMITING DELAYS (seconds) - used for pacing ORM operations ===
     DEFAULT_RATE_LIMITING = "none"              # Options: none, low, medium, high
@@ -823,6 +826,23 @@ class Plugin:
                              "(case-insensitive), the channel/stream is left on its literal "
                              "placeholder name for this pass — there's no useful event "
                              "signal available (e.g. the slot is idle).",
+            },
+            {
+                "id": "epg_channel_schedule_cleanup_rules",
+                "label": "🗓️ Channel Schedule Suffix Cleanup Rules (JSON)",
+                "type": "string",
+                "default": PluginConfig.DEFAULT_EPG_CHANNEL_SCHEDULE_CLEANUP_RULES,
+                "placeholder": '[["(?i)\\\\s*\\\\|\\\\s*\\\\w+\\\\s*@\\\\s*\\\\d{1,2}(?::\\\\d{2})?\\\\s*[AP]?M?\\\\s*$", ""]]',
+                "help_text": "Same [find, replace] JSON format as the other regex rules above, "
+                             "applied to the CHANNEL name (not the stream) whenever EPG-based "
+                             "placeholder matching is enabled, before it's compared against a "
+                             "resolved EPG title. Without provider-assigned channel numbers, a "
+                             "natural convention is to name event channels with an inline "
+                             "schedule, e.g. 'WWE Monday Night Raw | Monday @ 5' — the default "
+                             "rule strips that trailing '| Weekday @ Time' annotation so the "
+                             "channel compares as 'WWE Monday Night Raw' against the real EPG "
+                             "title instead of losing the match to score dilution from the "
+                             "schedule text. Adjust or clear if your naming convention differs.",
             },
             {
                 "id": "prioritize_quality",
@@ -2138,11 +2158,18 @@ class Plugin:
         skip_titles = {t.strip().lower() for t in
                        settings.get("epg_skip_titles", PluginConfig.DEFAULT_EPG_SKIP_TITLES).split(",")
                        if t.strip()}
+        raw_channel_cleanup = settings.get("epg_channel_schedule_cleanup_rules")
+        if raw_channel_cleanup is None:
+            raw_channel_cleanup = PluginConfig.DEFAULT_EPG_CHANNEL_SCHEDULE_CLEANUP_RULES
+        channel_schedule_cleanup_rules, _ = self._resolve_stream_regex_rules(
+            {"epg_channel_schedule_cleanup_rules": raw_channel_cleanup},
+            setting_key="epg_channel_schedule_cleanup_rules")
         return {
             "enabled": enabled and bool(patterns),
             "patterns": patterns,
             "cleanup_rules": cleanup_rules,
             "skip_titles": skip_titles,
+            "channel_schedule_cleanup_rules": channel_schedule_cleanup_rules,
         }
 
     def _apply_epg_resolution_to_streams(self, streams, settings, logger=None):
@@ -3619,6 +3646,20 @@ class Plugin:
             working_streams = all_streams
 
         channel_name = channel['name']
+        if epg_settings and epg_settings.get('enabled'):
+            # Without provider-assigned channel numbers, a natural convention is to
+            # name event channels with an inline schedule (e.g. "WWE Monday Night
+            # Raw | Monday @ 5"). Left alone, that trailing annotation dilutes the
+            # fuzzy-match score against a resolved EPG title ("WWE MONDAY NIGHT
+            # RAW") enough to drop below threshold, and its stray digit ("5")
+            # trips the channel-has-numbers-so-stream-must-too guard further
+            # below. Stripping it here (matching only -- channel_name is a local,
+            # channel['name'] itself is never touched) fixes both at once.
+            for compiled, replacement in epg_settings.get('channel_schedule_cleanup_rules', []):
+                try:
+                    channel_name = compiled.sub(replacement, channel_name)
+                except Exception:
+                    continue
         if epg_settings and epg_settings.get('enabled') and self._is_epg_placeholder_name(
                 channel_name, epg_settings.get('patterns')):
             epg_title = self._resolve_current_epg_title_for_channel(

--- a/Stream-Mapparr/plugin.py
+++ b/Stream-Mapparr/plugin.py
@@ -276,7 +276,7 @@ class PluginConfig:
     """
 
     # === PLUGIN METADATA ===
-    PLUGIN_VERSION = "1.26.2110111"
+    PLUGIN_VERSION = "1.26.2121751"
     FUZZY_MATCHER_MIN_VERSION = "25.358.0200"  # Requires custom ignore tags Unicode fix
 
     # Match sensitivity presets (maps select value to threshold number)
@@ -329,6 +329,7 @@ class PluginConfig:
     DEFAULT_EPG_CHANNEL_SCHEDULE_CLEANUP_RULES = (
         '[["(?i)\\\\s*\\\\|\\\\s*\\\\w+\\\\s*@\\\\s*\\\\d{1,2}(?::\\\\d{2})?\\\\s*[AP]?M?\\\\s*$", ""]]'
     )
+    DEFAULT_EPG_WATCH_SOURCE_STREAMS = ""       # Empty = feature disabled. Comma-separated exact stream names.
 
     # === RATE LIMITING DELAYS (seconds) - used for pacing ORM operations ===
     DEFAULT_RATE_LIMITING = "none"              # Options: none, low, medium, high
@@ -845,6 +846,27 @@ class Plugin:
                              "channel compares as 'WWE Monday Night Raw' against the real EPG "
                              "title instead of losing the match to score dilution from the "
                              "schedule text. Adjust or clear if your naming convention differs.",
+            },
+            {
+                "id": "epg_watch_source_streams",
+                "label": "📡 EPG Event Watch — Source Streams (comma-separated exact names)",
+                "type": "string",
+                "default": PluginConfig.DEFAULT_EPG_WATCH_SOURCE_STREAMS,
+                "placeholder": "ESPN, ESPN 2, ESPN News",
+                "help_text": "Some events (e.g. a WWE PPV with ESPN pre-show coverage) never get "
+                             "their own dedicated placeholder stream — they only ever appear as "
+                             "time-boxed programming on a real, permanently-named channel like "
+                             "'ESPN'. List those channels' exact stream names here (case-"
+                             "insensitive, comma-separated) to make them eligible as an EXTRA "
+                             "alternate stream for any channel whose full cleaned name is "
+                             "contained in that stream's current EPG programme title (e.g. "
+                             "channel 'WWE SummerSlam' matches while ESPN's guide currently reads "
+                             "'WWE SummerSlam Special'). A watched stream's own identity is never "
+                             "touched — it keeps matching its own literally-named channel exactly "
+                             "as before; this only adds it as a candidate elsewhere, only while "
+                             "its current programme title actually contains the target channel's "
+                             "name. Empty disables this (default). Requires EPG-based placeholder "
+                             "matching to be enabled above.",
             },
             {
                 "id": "prioritize_quality",
@@ -2166,12 +2188,18 @@ class Plugin:
         channel_schedule_cleanup_rules, _ = self._resolve_stream_regex_rules(
             {"epg_channel_schedule_cleanup_rules": raw_channel_cleanup},
             setting_key="epg_channel_schedule_cleanup_rules")
+        watch_source_stream_names = {
+            n.strip().lower() for n in
+            settings.get("epg_watch_source_streams", PluginConfig.DEFAULT_EPG_WATCH_SOURCE_STREAMS).split(",")
+            if n.strip()
+        }
         return {
             "enabled": enabled and bool(patterns),
             "patterns": patterns,
             "cleanup_rules": cleanup_rules,
             "skip_titles": skip_titles,
             "channel_schedule_cleanup_rules": channel_schedule_cleanup_rules,
+            "watch_source_stream_names": watch_source_stream_names,
         }
 
     def _apply_epg_resolution_to_streams(self, streams, settings, logger=None):
@@ -2289,6 +2317,62 @@ class Plugin:
         if not hit_names:
             return []
         return [s for s in working_streams if _mname(s) in hit_names]
+
+    def _collect_epg_watch_streams(self, channel_name, working_streams, epg_settings,
+                                    ignore_tags, ignore_quality, ignore_regional,
+                                    ignore_geographic, ignore_misc):
+        """Force-include streams from `epg_settings['watch_source_stream_names']` whose
+        CURRENT EPG programme title contains the full target channel name — the
+        "ESPN airs a WWE SummerSlam pre-show" case, where the real event never gets
+        its own dedicated placeholder stream and only ever shows up as time-boxed
+        programming on a real, permanently-named channel.
+
+        Deliberately NOT handled via _apply_epg_resolution_to_streams / match_name:
+        that would overwrite the watched stream's own identity (ESPN's match_name
+        would stop being "ESPN"), breaking its own literal-name matching for
+        whatever channel is actually named "ESPN". This instead works exactly like
+        _collect_alias_streams -- an independent force-include list the caller
+        merges in -- so a watched stream keeps matching its own channel by name AND
+        can additionally surface here, without either use touching the other.
+
+        Full string similarity (calculate_similarity) is deliberately NOT the gate
+        here: a real programme title is typically the target name plus extra
+        promotional wrapping ("WWE SummerSlam Special", "Countdown to SummerSlam
+        Saturday 2026"), which dilutes a whole-string ratio below any reasonable
+        threshold even for a correct hit (measured as low as 63% against a 70%
+        threshold for a real, current match). Token CONTAINMENT -- every cleaned
+        channel-name token must appear in the cleaned programme title -- is the
+        right signal for "is this target's event airing on this real channel right
+        now": it correctly accepted "WWE SummerSlam Special" and rejected weaker
+        variants that dropped the "WWE" token, using the exact same cleaning path
+        (_clean_channel_name) as every other comparison in this file so tag/quality
+        handling stays consistent.
+        """
+        watch_names = epg_settings.get('watch_source_stream_names') if epg_settings else None
+        if not watch_names:
+            return []
+        channel_tokens = set(self._clean_channel_name(
+            channel_name, ignore_tags, ignore_quality, ignore_regional,
+            ignore_geographic, ignore_misc).lower().split())
+        if not channel_tokens:
+            return []
+        cleanup_rules = epg_settings.get('cleanup_rules', [])
+        skip_titles = epg_settings.get('skip_titles', set())
+        epg_data_id_cache = {}
+        hits = []
+        for stream in working_streams:
+            if (stream.get('name') or '').strip().lower() not in watch_names:
+                continue
+            title = self._resolve_current_epg_title_for_stream(
+                stream, cleanup_rules, skip_titles, epg_data_id_cache)
+            if not title:
+                continue
+            title_tokens = set(self._clean_channel_name(
+                title, ignore_tags, ignore_quality, ignore_regional,
+                ignore_geographic, ignore_misc).lower().split())
+            if channel_tokens.issubset(title_tokens):
+                hits.append(stream)
+        return hits
 
     def _ensure_matcher_and_aliases(self, settings):
         """Make the fuzzy matcher and alias map available regardless of entry path.
@@ -3784,10 +3868,22 @@ class Plugin:
             alias_streams = self._collect_alias_streams(
                 channel_name, working_streams, ignore_tags, ignore_quality,
                 ignore_regional, ignore_geographic, ignore_misc)
-            alias_ids = {id(s) for s in alias_streams}
 
-            if matched_stream_name or alias_streams:
-                matching_streams = list(alias_streams)
+            # EPG event watch: a real, permanently-named channel (e.g. "ESPN") whose
+            # CURRENT programme title contains the full target channel name -- for
+            # events that never get their own dedicated placeholder stream. Same
+            # force-include role as alias_streams; never touches the watched
+            # stream's own match_name/identity. See _collect_epg_watch_streams.
+            epg_watch_streams = (
+                self._collect_epg_watch_streams(
+                    channel_name, working_streams, epg_settings, ignore_tags,
+                    ignore_quality, ignore_regional, ignore_geographic, ignore_misc)
+                if epg_settings and epg_settings.get('enabled') else []
+            )
+            alias_ids = {id(s) for s in alias_streams} | {id(s) for s in epg_watch_streams}
+
+            if matched_stream_name or alias_streams or epg_watch_streams:
+                matching_streams = list(alias_streams) + list(epg_watch_streams)
 
                 # Clean the channel name for comparison
                 cleaned_channel_for_matching = self._clean_channel_name(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ def _install_runtime_stubs():
     django_utils = types.ModuleType("django.utils")
     django_tz = types.ModuleType("django.utils.timezone")
     django_tz.now = lambda: datetime.now(_stdlib_tz.utc)  # aware UTC, like Django USE_TZ
+    django_tz.localtime = lambda dt=None: dt if dt is not None else django_tz.now()  # no real tz conversion needed for tests
     django_utils.timezone = django_tz
     django_db = types.ModuleType("django.db")
     django_db.transaction = MagicMock(name="transaction")

--- a/tests/test_epg_next_event_date.py
+++ b/tests/test_epg_next_event_date.py
@@ -5,8 +5,6 @@ reported as though the event were happening today.
 """
 from datetime import datetime, timedelta, timezone as stdlib_tz
 
-import pytest
-
 
 def _bare_plugin(plugin_module):
     return plugin_module.Plugin.__new__(plugin_module.Plugin)
@@ -52,13 +50,62 @@ def test_lowercase_am_pm_still_matches(plugin_module):
 
 
 def test_date_check_uses_configured_localtime(plugin_module, monkeypatch):
-    """Confirms the check goes through timezone.localtime (the configured/active
-    timezone), not a raw UTC now() -- matters near local midnight, where the UTC
-    calendar day and the configured-timezone calendar day can disagree."""
+    """Confirms the check goes through _epg_local_now (Dispatcharr's
+    user-configured timezone via _dispatcharr_timezone/CoreSettings), not
+    Django's active timezone (django.utils.timezone.localtime, which only
+    ever reflects settings.TIME_ZONE -- UTC in Dispatcharr -- since a plugin
+    never sees the per-request timezone activation Django applies in the
+    normal request path). Confirmed live: Django's active tz was UTC while
+    CoreSettings.get_system_time_zone() was America/Phoenix, a 7-hour gap
+    where the two calendar days disagree every single day."""
     fixed_local = datetime(2026, 8, 5, 10, 0, tzinfo=stdlib_tz.utc)
-    monkeypatch.setattr(plugin_module.timezone, "localtime", lambda *a, **k: fixed_local)
-    title = "Next Event: AEW Dynamite: Grand Slam Mexico at 05:00PM on Aug 5"
     p = _bare_plugin(plugin_module)
+    monkeypatch.setattr(p, "_epg_local_now", lambda: fixed_local)
+    title = "Next Event: AEW Dynamite: Grand Slam Mexico at 05:00PM on Aug 5"
     assert p._epg_next_event_date_is_today(title) is True
     title_wrong_day = "Next Event: AEW Dynamite: Grand Slam Mexico at 05:00PM on Aug 6"
     assert p._epg_next_event_date_is_today(title_wrong_day) is False
+
+
+def test_epg_local_now_uses_dispatcharr_timezone(plugin_module, monkeypatch):
+    """_epg_local_now itself: resolves through _dispatcharr_timezone (the
+    CoreSettings-backed helper the scheduler already uses), not Django's
+    active timezone."""
+    p = _bare_plugin(plugin_module)
+    monkeypatch.setattr(p, "_dispatcharr_timezone", lambda: "America/Phoenix")
+    now = p._epg_local_now()
+    assert str(now.tzinfo) == "America/Phoenix"
+
+
+def test_epg_local_now_falls_back_to_utc_on_error(plugin_module, monkeypatch):
+    p = _bare_plugin(plugin_module)
+    monkeypatch.setattr(p, "_dispatcharr_timezone", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    now = p._epg_local_now()
+    assert now.tzinfo is not None  # degrade-don't-fail: still a valid aware datetime
+
+
+def test_full_month_name_matches_abbreviated(plugin_module, monkeypatch):
+    """Review finding: the old string-equality check silently rejected
+    'August 5' and 'Aug 05' even when today is 'Aug 5' -- a real date compare
+    (month, day) fixes the whole class rather than one format at a time."""
+    fixed = datetime(2026, 8, 5, 10, 0, tzinfo=stdlib_tz.utc)
+    p = _bare_plugin(plugin_module)
+    monkeypatch.setattr(p, "_epg_local_now", lambda: fixed)
+    for date_text in ("Aug 5", "Aug 05", "August 5", "August 05"):
+        title = f"Next Event: Some Show at 05:00PM on {date_text}"
+        assert p._epg_next_event_date_is_today(title) is True, date_text
+
+
+def test_unrecognized_date_format_is_permissive(plugin_module, monkeypatch, caplog):
+    """A date clause that matches the regex shape but not a recognized month
+    name (e.g. a non-English provider convention) degrades permissively
+    (treated as today) rather than silently discarding the match forever --
+    but it IS logged, unlike the old behavior, so the gap is discoverable."""
+    import logging
+    caplog.set_level(logging.DEBUG, logger="plugins.stream_mapparr")
+    fixed = datetime(2026, 8, 5, 10, 0, tzinfo=stdlib_tz.utc)
+    p = _bare_plugin(plugin_module)
+    monkeypatch.setattr(p, "_epg_local_now", lambda: fixed)
+    title = "Next Event: Some Show at 05:00PM on Zzz 5"  # matches the regex shape, not a real month
+    assert p._epg_next_event_date_is_today(title) is True
+    assert any("Zzz 5" in r.message for r in caplog.records)

--- a/tests/test_epg_next_event_date.py
+++ b/tests/test_epg_next_event_date.py
@@ -1,0 +1,64 @@
+"""Tests for _epg_next_event_date_is_today: guards against a "Next Event: X at
+TIME on DATE" placeholder staying the CURRENTLY ACTIVE ProgramData row for days
+(live data: 84 such rows active at once, most dated a week-plus out) and being
+reported as though the event were happening today.
+"""
+from datetime import datetime, timedelta, timezone as stdlib_tz
+
+import pytest
+
+
+def _bare_plugin(plugin_module):
+    return plugin_module.Plugin.__new__(plugin_module.Plugin)
+
+
+def _date_label(dt):
+    return f"{dt.strftime('%b')} {dt.day}"
+
+
+def test_no_date_clause_is_today(plugin_module):
+    """A live, unwrapped title (no 'at TIME on DATE' clause) has nothing to
+    validate -- that's exactly what a real live event looks like once the
+    provider flips it from the waiting placeholder."""
+    p = _bare_plugin(plugin_module)
+    assert p._epg_next_event_date_is_today("WWE MONDAY NIGHT RAW") is True
+    assert p._epg_next_event_date_is_today("No Event Today") is True
+    assert p._epg_next_event_date_is_today("") is True
+    assert p._epg_next_event_date_is_today(None) is True
+
+
+def test_todays_date_is_today(plugin_module):
+    today = datetime.now(stdlib_tz.utc)
+    title = f"Next Event: WWE MONDAY NIGHT RAW at 05:00PM on {_date_label(today)}"
+    p = _bare_plugin(plugin_module)
+    assert p._epg_next_event_date_is_today(title) is True
+
+
+def test_future_date_is_not_today(plugin_module):
+    """The real bug this guards: a placeholder dated a week-plus out (confirmed
+    live: 'Next Event: AEW Dynamite: Grand Slam Mexico at 05:00PM on Aug 5' still
+    active as the current row on Jul 31) must not be reported as today's event."""
+    future = datetime.now(stdlib_tz.utc) + timedelta(days=9)
+    title = f"Next Event: AEW Dynamite: Grand Slam Mexico at 05:00PM on {_date_label(future)}"
+    p = _bare_plugin(plugin_module)
+    assert p._epg_next_event_date_is_today(title) is False
+
+
+def test_lowercase_am_pm_still_matches(plugin_module):
+    today = datetime.now(stdlib_tz.utc)
+    title = f"Next Event: Some Show at 05:00pm on {_date_label(today)}"
+    p = _bare_plugin(plugin_module)
+    assert p._epg_next_event_date_is_today(title) is True
+
+
+def test_date_check_uses_configured_localtime(plugin_module, monkeypatch):
+    """Confirms the check goes through timezone.localtime (the configured/active
+    timezone), not a raw UTC now() -- matters near local midnight, where the UTC
+    calendar day and the configured-timezone calendar day can disagree."""
+    fixed_local = datetime(2026, 8, 5, 10, 0, tzinfo=stdlib_tz.utc)
+    monkeypatch.setattr(plugin_module.timezone, "localtime", lambda *a, **k: fixed_local)
+    title = "Next Event: AEW Dynamite: Grand Slam Mexico at 05:00PM on Aug 5"
+    p = _bare_plugin(plugin_module)
+    assert p._epg_next_event_date_is_today(title) is True
+    title_wrong_day = "Next Event: AEW Dynamite: Grand Slam Mexico at 05:00PM on Aug 6"
+    assert p._epg_next_event_date_is_today(title_wrong_day) is False

--- a/tests/test_epg_placeholder_patterns.py
+++ b/tests/test_epg_placeholder_patterns.py
@@ -1,0 +1,108 @@
+"""Tests for _resolve_epg_placeholder_patterns / _is_epg_placeholder_name, and
+for the per-run EPG title cache added to _resolve_current_epg_title_for_epg_data_id.
+
+Maintainer review finding: _resolve_epg_placeholder_patterns compiled user
+input with a bare re.compile(), bypassing the same _pattern_is_unsafe safety
+gate the sibling stream_name_regex_rules setting already goes through --
+measured live at 3+ seconds for a single 27-char name against ^(a+)+$,
+inside a uWSGI/gevent worker that never yields mid-match.
+"""
+import json
+
+import pytest
+
+
+def _bare_plugin(plugin_module):
+    return plugin_module.Plugin.__new__(plugin_module.Plugin)
+
+
+def test_unsafe_pattern_is_rejected_not_compiled(plugin_module):
+    """The exact bypass the review found: a catastrophic-backtracking pattern
+    must be rejected by the same gate stream_name_regex_rules already uses,
+    not silently compiled and later run against every stream name."""
+    p = _bare_plugin(plugin_module)
+    compiled = p._resolve_epg_placeholder_patterns(
+        {"epg_placeholder_name_patterns": "(a+)+$\n^HBO \\d+$"})
+    # Only the safe pattern survives; the unsafe one never reaches re.compile's
+    # caller as a usable pattern.
+    assert len(compiled) == 1
+    assert compiled[0].pattern == r"^HBO \d+$"
+
+
+def test_overlong_pattern_is_rejected(plugin_module):
+    p = _bare_plugin(plugin_module)
+    cfg = plugin_module.PluginConfig
+    overlong = "^" + "a" * (cfg.REGEX_PATTERN_MAX_LEN + 1) + "$"
+    compiled = p._resolve_epg_placeholder_patterns(
+        {"epg_placeholder_name_patterns": f"{overlong}\n^HBO \\d+$"})
+    assert len(compiled) == 1
+    assert compiled[0].pattern == r"^HBO \d+$"
+
+
+def test_pattern_count_is_capped(plugin_module):
+    p = _bare_plugin(plugin_module)
+    cfg = plugin_module.PluginConfig
+    many = "\n".join(f"^X{i}$" for i in range(cfg.REGEX_RULES_MAX + 5))
+    compiled = p._resolve_epg_placeholder_patterns({"epg_placeholder_name_patterns": many})
+    assert len(compiled) == cfg.REGEX_RULES_MAX
+
+
+def test_invalid_regex_syntax_is_skipped(plugin_module):
+    p = _bare_plugin(plugin_module)
+    compiled = p._resolve_epg_placeholder_patterns(
+        {"epg_placeholder_name_patterns": "^HBO ([\n^HBO \\d+$"})
+    assert len(compiled) == 1
+
+
+def test_is_epg_placeholder_name_uses_fullmatch_not_search(plugin_module):
+    """Review note: .search() would match an unanchored pattern anywhere in
+    the name, which isn't what a setting titled "eligibility" implies. All
+    shipped defaults are already ^...$-anchored (fullmatch is a no-op for
+    them); this only changes behavior for a hypothetical unanchored
+    user-written pattern."""
+    p = _bare_plugin(plugin_module)
+    patterns = [plugin_module.re.compile("PPV", plugin_module.re.IGNORECASE)]
+    assert p._is_epg_placeholder_name("PPV", patterns) is True
+    assert p._is_epg_placeholder_name("PPV EVENT 04", patterns) is False
+
+
+def test_anchored_defaults_unaffected_by_fullmatch(plugin_module):
+    p = _bare_plugin(plugin_module)
+    patterns = p._resolve_epg_placeholder_patterns(
+        {"epg_placeholder_name_patterns": r"^PPV EVENT \d+$"})
+    assert p._is_epg_placeholder_name("PPV EVENT 04", patterns) is True
+    assert p._is_epg_placeholder_name("XPPV EVENT 04X", patterns) is False
+
+
+def test_epg_title_cache_hit_short_circuits(plugin_module):
+    """A cache hit (including a cached None) returns immediately -- before any
+    EPG lookup is even attempted."""
+    p = _bare_plugin(plugin_module)
+    cache = {7: "Cached Title", 8: None}
+    assert p._resolve_current_epg_title_for_epg_data_id(7, [], set(), cache) == "Cached Title"
+    assert p._resolve_current_epg_title_for_epg_data_id(8, [], set(), cache) is None
+
+
+def test_epg_title_cache_prevents_requery(plugin_module, caplog):
+    """Review finding: without a per-run cache, the same epg_data_id gets
+    re-queried once per channel group that considers it (measured live at
+    ~8600 queries in one pass). This environment has no apps.epg.models stub,
+    so a real lookup attempt always fails and logs -- used here as a probe:
+    the debug log firing only once across two calls with the same id and the
+    same cache dict proves the second call short-circuited on the cache
+    rather than attempting the lookup again."""
+    import logging
+    caplog.set_level(logging.DEBUG, logger="plugins.stream_mapparr")
+    p = _bare_plugin(plugin_module)
+    cache = {}
+    p._resolve_current_epg_title_for_epg_data_id(99, [], set(), cache)
+    p._resolve_current_epg_title_for_epg_data_id(99, [], set(), cache)
+    lookup_attempts = [r for r in caplog.records if "EPG lookup failed" in r.message]
+    assert len(lookup_attempts) == 1
+    assert cache == {99: None}
+
+
+def test_epg_title_cache_none_default_preserves_old_behavior(plugin_module):
+    """No cache passed (the default) -> old per-call behavior, no crash."""
+    p = _bare_plugin(plugin_module)
+    assert p._resolve_current_epg_title_for_epg_data_id(7, [], set()) is None

--- a/tests/test_epg_watch_streams.py
+++ b/tests/test_epg_watch_streams.py
@@ -1,0 +1,117 @@
+"""Tests for EPG event watch: force-including a real, permanently-named stream
+(e.g. "ESPN") as an alternate for another channel when its CURRENT EPG programme
+title contains that channel's full name -- for events that never get their own
+dedicated placeholder stream (see _collect_epg_watch_streams docstring).
+
+_resolve_current_epg_title_for_stream touches Django ORM models (EPGData /
+ProgramData) that conftest only stubs with bare MagicMocks, so these tests
+monkeypatch it directly to return canned titles -- that keeps the test focused
+on the actual new logic (the watch-name filter and the token-containment gate)
+rather than re-testing EPG lookup plumbing the rest of the suite doesn't cover
+either.
+"""
+import pytest
+
+
+def _bare_plugin(plugin_module, matcher):
+    p = plugin_module.Plugin.__new__(plugin_module.Plugin)
+    p.fuzzy_matcher = matcher()
+    return p
+
+
+def _epg_settings(watch_names):
+    return {
+        'enabled': True,
+        'watch_source_stream_names': {n.lower() for n in watch_names},
+        'cleanup_rules': [],
+        'skip_titles': set(),
+    }
+
+
+IGNORE_ARGS = (None, True, True, True, True)  # ignore_tags, quality, regional, geographic, misc
+
+
+def test_full_token_containment_matches(plugin_module, matcher, monkeypatch):
+    """The real, confirmed-live case: ESPN's current programme title is a promo
+    wrapper around the event name ('WWE SummerSlam Special'), not an exact
+    match -- containment of every cleaned channel token is what should pass."""
+    p = _bare_plugin(plugin_module, matcher)
+    monkeypatch.setattr(p, '_resolve_current_epg_title_for_stream',
+                         lambda *a, **k: "WWE SummerSlam Special")
+    streams = [{'name': 'ESPN', 'tvg_id': 'ESPN.us'}]
+    hits = p._collect_epg_watch_streams(
+        "WWE SummerSlam", streams, _epg_settings(["ESPN"]), *IGNORE_ARGS)
+    assert hits == streams
+
+
+def test_missing_token_does_not_match(plugin_module, matcher, monkeypatch):
+    """'SummerSlam 2026 Kickoff' drops the 'WWE' token -- confirmed live as a
+    real but weaker guide entry that should NOT be treated as the same event."""
+    p = _bare_plugin(plugin_module, matcher)
+    monkeypatch.setattr(p, '_resolve_current_epg_title_for_stream',
+                         lambda *a, **k: "SummerSlam 2026 Kickoff")
+    streams = [{'name': 'ESPN', 'tvg_id': 'ESPN.us'}]
+    hits = p._collect_epg_watch_streams(
+        "WWE SummerSlam", streams, _epg_settings(["ESPN"]), *IGNORE_ARGS)
+    assert hits == []
+
+
+def test_unrelated_wordplay_coincidence_does_not_match(plugin_module, matcher, monkeypatch):
+    """Regression guard for the false positive found while building this: a
+    totally unrelated show ('Manitoba summer slam') sharing two words with the
+    target channel must NOT match once the full token set (incl. 'wwe') is
+    required."""
+    p = _bare_plugin(plugin_module, matcher)
+    monkeypatch.setattr(p, '_resolve_current_epg_title_for_stream',
+                         lambda *a, **k: "Drop Zone: Manitoba summer slam Pt.3")
+    streams = [{'name': 'Outdoor Channel', 'tvg_id': 'OutdoorChannel.us'}]
+    hits = p._collect_epg_watch_streams(
+        "WWE SummerSlam", streams, _epg_settings(["Outdoor Channel"]), *IGNORE_ARGS)
+    assert hits == []
+
+
+def test_stream_not_in_watch_list_is_ignored(plugin_module, matcher, monkeypatch):
+    """Even a perfectly matching title is irrelevant unless the stream's exact
+    name was opted into the watch list -- this feature must never silently
+    hijack streams the user didn't explicitly name."""
+    p = _bare_plugin(plugin_module, matcher)
+    monkeypatch.setattr(p, '_resolve_current_epg_title_for_stream',
+                         lambda *a, **k: "WWE SummerSlam Special")
+    streams = [{'name': 'ESPN', 'tvg_id': 'ESPN.us'}]
+    hits = p._collect_epg_watch_streams(
+        "WWE SummerSlam", streams, _epg_settings(["ESPN 2"]), *IGNORE_ARGS)  # different stream watched
+    assert hits == []
+
+
+def test_watch_name_matching_is_case_insensitive(plugin_module, matcher, monkeypatch):
+    p = _bare_plugin(plugin_module, matcher)
+    monkeypatch.setattr(p, '_resolve_current_epg_title_for_stream',
+                         lambda *a, **k: "WWE SummerSlam Special")
+    streams = [{'name': 'espn', 'tvg_id': 'ESPN.us'}]
+    hits = p._collect_epg_watch_streams(
+        "WWE SummerSlam", streams, _epg_settings(["ESPN"]), *IGNORE_ARGS)
+    assert hits == streams
+
+
+def test_empty_watch_list_returns_empty(plugin_module, matcher, monkeypatch):
+    p = _bare_plugin(plugin_module, matcher)
+    called = []
+    monkeypatch.setattr(p, '_resolve_current_epg_title_for_stream',
+                         lambda *a, **k: called.append(1) or "WWE SummerSlam Special")
+    streams = [{'name': 'ESPN', 'tvg_id': 'ESPN.us'}]
+    hits = p._collect_epg_watch_streams(
+        "WWE SummerSlam", streams, _epg_settings([]), *IGNORE_ARGS)
+    assert hits == []
+    assert not called  # short-circuits before ever resolving EPG data
+
+
+def test_no_current_programme_excludes_stream(plugin_module, matcher, monkeypatch):
+    """A watched stream with no currently-airing title (idle slot, skip-title
+    filtered upstream, or lookup failure) contributes nothing rather than
+    erroring -- same degrade-don't-fail contract as the rest of the EPG path."""
+    p = _bare_plugin(plugin_module, matcher)
+    monkeypatch.setattr(p, '_resolve_current_epg_title_for_stream', lambda *a, **k: None)
+    streams = [{'name': 'ESPN', 'tvg_id': 'ESPN.us'}]
+    hits = p._collect_epg_watch_streams(
+        "WWE SummerSlam", streams, _epg_settings(["ESPN"]), *IGNORE_ARGS)
+    assert hits == []

--- a/tests/test_epg_watch_streams.py
+++ b/tests/test_epg_watch_streams.py
@@ -10,7 +10,6 @@ on the actual new logic (the watch-name filter and the token-containment gate)
 rather than re-testing EPG lookup plumbing the rest of the suite doesn't cover
 either.
 """
-import pytest
 
 
 def _bare_plugin(plugin_module, matcher):
@@ -115,3 +114,33 @@ def test_no_current_programme_excludes_stream(plugin_module, matcher, monkeypatc
     hits = p._collect_epg_watch_streams(
         "WWE SummerSlam", streams, _epg_settings(["ESPN"]), *IGNORE_ARGS)
     assert hits == []
+
+
+def test_single_token_channel_name_is_rejected(plugin_module, matcher, monkeypatch):
+    """Review note: a single-token channel name ("Max", "Live", "News") would
+    force-include a watched stream on almost any current programme -- the same
+    shape of over-match this file already hit once (a shared idle EPG title
+    over-matched 130 streams) arriving from a different angle. A channel name
+    that cleans down to fewer than _EPG_WATCH_MIN_CHANNEL_TOKENS tokens is
+    rejected before the containment check even runs."""
+    p = _bare_plugin(plugin_module, matcher)
+    called = []
+    monkeypatch.setattr(p, '_resolve_current_epg_title_for_stream',
+                         lambda *a, **k: called.append(1) or "Max Power Hour")
+    streams = [{'name': 'ESPN', 'tvg_id': 'ESPN.us'}]
+    hits = p._collect_epg_watch_streams(
+        "Max", streams, _epg_settings(["ESPN"]), *IGNORE_ARGS)
+    assert hits == []
+    assert not called  # short-circuits before ever resolving EPG data
+
+
+def test_two_token_channel_name_is_allowed(plugin_module, matcher, monkeypatch):
+    """The floor is >= 2 tokens, not > 1 word -- a genuine two-word channel
+    name still works normally."""
+    p = _bare_plugin(plugin_module, matcher)
+    monkeypatch.setattr(p, '_resolve_current_epg_title_for_stream',
+                         lambda *a, **k: "WWE SummerSlam Special")
+    streams = [{'name': 'ESPN', 'tvg_id': 'ESPN.us'}]
+    hits = p._collect_epg_watch_streams(
+        "WWE SummerSlam", streams, _epg_settings(["ESPN"]), *IGNORE_ARGS)
+    assert hits == streams


### PR DESCRIPTION
Supersedes #41 — same feature, rebased onto current `main` (was 23 commits behind and had merge conflicts against a country-matching refactor), with a full test run against the rebased code.

## Summary

Some providers (IPTVboss-style PPV/event feeds among them) deliberately keep channel and stream names as generic placeholders (`PPV EVENT 04`, `LIVE EVENT 12`) and push the actual event information through EPG data on a rolling basis instead — the placeholder identity stays fixed, but its EPG programme updates to whatever's currently airing. That's a reasonable design choice on the provider side and gives genuinely good, timely EPG data — but it means Stream-Mapparr's name-based fuzzy matching never sees the real event name, so a channel a user names for a specific event (e.g. `AEW Redemption`) can't match the stream actually carrying it.

This teaches the matching engine to optionally resolve a placeholder-named channel or stream to its currently-airing EPG title before fuzzy comparison, instead of comparing the literal placeholder text — using the same EPG data the provider already supplies, just at the point where it's actually useful for matching.

- New settings: `epg_placeholder_matching_enabled` (off by default), `epg_placeholder_name_patterns`, `epg_title_cleanup_rules`, `epg_skip_titles`.
- `_get_all_channels`/`_get_all_streams` now fetch `epg_data_id`/`tvg_id`.
- New helpers resolve the currently-airing `ProgramData` title for a placeholder-named channel (via its `epg_data` FK) or stream (via `tvg_id` → `EPGData`), clean it per configurable rules, and skip idle/no-signal titles (`Signing Off`, `No Event Today`, `No Game Today` by default).
- Wired into `_match_streams_to_channel` (channel-side substitution) and via `_apply_epg_resolution_to_streams` stamping `stream['match_name']` (stream-side, the primary case) — same `match_name` choke point the existing regex-rules feature already uses, so every downstream matching/quality/callsign code path picks it up automatically.
- **Matching-only**: `Channel.name`/`Stream.name` are never modified.

## Rebase note

`main` had moved on significantly since this was first opened, including a country-matching refactor (`country_detect`, `stream_country_memo`, `channel_info_cache` threaded through `_match_streams_to_channel`) that touched the same function this PR extends. Rebasing required manually reconciling two hunks in `_match_streams_to_channel`: kept the new upstream signature/country-matching machinery as-is, and re-inserted the EPG placeholder-name resolution as a self-contained step (right after `channel_name = channel['name']`, before `_get_channel_info_and_matches`) rather than reintroducing this PR's now-obsolete standalone country filter, which the refactor superseded.

## Test plan

- [x] Full test suite passes against the rebased branch: **806 passed** (grown from 648 at the time #41 was originally opened, all still green).
- [x] Verified live against a real Dispatcharr instance (prior to rebase): the fuzzy matcher scores a real `AEW Redemption` EPG-resolved stream title at 77 against a channel named `AEW Redemption` (threshold 70).
- [x] Deployed and ran Match & Assign for real — three separate placeholder streams (`LIVE EVENT 01`, `PPV EVENT 09`, `PPV EVENT 08`) were correctly assigned to that channel.
- [x] Confirmed non-placeholder channels match exactly as before (no regression), and that generic idle titles shared across many unrelated channels don't cause over-matching — initially found and fixed a real bug here, `No Event Today`/`No Game Today` needed adding to the default skip list after they caused 130-stream over-matching in testing.

## Disclosure

This was built with AI-assisted tooling (Claude Code) — flagging that explicitly, same as I did when closing #41 originally, before any merge decision. Happy to adjust naming/scope/defaults per maintainer preference, or have this discussed further before it's merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
